### PR TITLE
feat: create "activable en autonomie" program field, add a CTA button on program display

### DIFF
--- a/packages/data/programs/audits-clef-verte.yaml
+++ b/packages/data/programs/audits-clef-verte.yaml
@@ -29,6 +29,7 @@ url: https://www.cci.fr/offre/valorisez-les-demarches-environnementales-de-votre
 nature de l'aide: accompagnement
 coût de l'accompagnement: De 350 à 450 € HT selon votre activité
 durée de l'accompagnement: 1 jour dont 1/2 journée sur site
+activable en autonomie: oui
 objectifs:
 - description: Créez un compte et réalisez un auto-diagnostic pour évaluer l'éligibilité
     de votre établissement au label. Cette étape est gratuite et sans engagement.

--- a/packages/data/programs/baisse-les-watts.yaml
+++ b/packages/data/programs/baisse-les-watts.yaml
@@ -25,6 +25,7 @@ url: https://www.baisseleswatts.fr/?mtm_campaign=missiontransitionecologique&mtm
 nature de l'aide: accompagnement
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 2 jours
+activable en autonomie: oui
 objectifs:
 - description: Créez votre compte entreprise sur le site de Baisse les Watts.
   liens:

--- a/packages/data/programs/bonus-ecologique.yaml
+++ b/packages/data/programs/bonus-ecologique.yaml
@@ -8,6 +8,7 @@ opérateur de contact: ASP
 url: https://www.primealaconversion.gouv.fr/dboneco/accueil/access.html
 nature de l'aide: financement
 montant du financement: jusqu’à 9 000 €, selon le véhicule
+activable en autonomie: oui
 objectifs:
 - description: Louez ou achetez votre véhicule "propre" et déposez votre demande de
     Bonus écologique dans les six mois.

--- a/packages/data/programs/coup-de-pouce-chauffage.yaml
+++ b/packages/data/programs/coup-de-pouce-chauffage.yaml
@@ -30,6 +30,7 @@ opérateur de contact: Ministère de la Transition Écologique et Solidaire
 url: ''
 nature de l'aide: financement
 montant du financement: Variable selon le bâtiment et le type d'équipement
+activable en autonomie: oui
 objectifs:
 - description: Vérifiez votre éligibilité en réalisant le test “Votre bâtiment est-il
     raccordable à un réseau de chaleur ?”. Si un réseau de chaleur passe à proximité

--- a/packages/data/programs/enviroveille.yaml
+++ b/packages/data/programs/enviroveille.yaml
@@ -10,6 +10,7 @@ url: https://www.enviroveille.com/public/tester-gratuitement.html
 nature de l'aide: accompagnement
 coût de l'accompagnement: de 150 à 800 € HT (sur abonnement)
 durée de l'accompagnement: 12 mois
+activable en autonomie: oui
 objectifs:
 - description: Recevez une alerte réglementaire une fois tous les 15 jours, comme
     premier niveau d'information sur l'actualité réglementaire.

--- a/packages/data/programs/etude-performance-produits.yaml
+++ b/packages/data/programs/etude-performance-produits.yaml
@@ -1,4 +1,4 @@
-titre: Étude "Éco-conception"
+titre: Étude "Performance produits"
 promesse: Évaluez la performance environnementale de vos produits, procédés et services
 description: L’ADEME propose une aide pour financer vos études d'éco-conception. Une
   approche qui conduit à l'amélioration environnementale de votre produit ou service

--- a/packages/data/programs/extreme-defi-mobilite.yaml
+++ b/packages/data/programs/extreme-defi-mobilite.yaml
@@ -37,6 +37,7 @@ url: https://airtable.com/apprjFOnbLySO8spa/shraH0xKsFZnkZOKw
 nature de l'aide: accompagnement
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: Jusqu'à 3 ans d'accompagnement
+activable en autonomie: oui
 objectifs:
 - description: Participez à des sessions de créativité pour faire émerger de nouveaux
     concepts d'objets roulants.

--- a/packages/data/programs/formation-engager-entreprise-transition-ecologique.yaml
+++ b/packages/data/programs/formation-engager-entreprise-transition-ecologique.yaml
@@ -16,6 +16,7 @@ url: https://formations.ademe.fr/formations_transition-ecologique-:-approche-tra
 nature de l'aide: formation
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 2h15
+activable en autonomie: oui
 objectifs:
 - description: Créez votre compte sur la plateforme ADEME Formations.
   liens:

--- a/packages/data/programs/formations-du-cfde.yaml
+++ b/packages/data/programs/formations-du-cfde.yaml
@@ -11,6 +11,7 @@ url: https://www.cci.fr/ressources/developpement-durable/cfde
 nature de l'aide: formation
 coût de l'accompagnement: Sur devis, selon la formation choisie
 durée de l'accompagnement: Selon la formation choisie
+activable en autonomie: oui
 objectifs:
 - description: Découvrez le catalogue de formation en transition écologique et énergétique
     que propose le CFDE aux entreprises.

--- a/packages/data/programs/formations-tee.yaml
+++ b/packages/data/programs/formations-tee.yaml
@@ -23,6 +23,7 @@ url: https://universite.bpifrance.fr/
 nature de l'aide: formation
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 1h
+activable en autonomie: oui
 objectifs:
 - description: Créez votre compte sur la plateforme Bpifrance Université dédiée aux
     dirigeants d'entreprises.

--- a/packages/data/programs/investissement-vte-vert.yaml
+++ b/packages/data/programs/investissement-vte-vert.yaml
@@ -20,6 +20,7 @@ autres opérateurs:
 url: https://www.vte-france.fr/aide-vte-vert/
 nature de l'aide: financement
 montant du financement: 50% des dépenses engagées dans la limite de 8000 €
+activable en autonomie: oui
 objectifs:
 - description: Vous n'avez pas encore trouvé votre talent VTE ? Créez votre espace
     recruteur sur le site vte-france. Depuis votre espace, vous pourrez publier une

--- a/packages/data/programs/prime-a-la-conversion.yaml
+++ b/packages/data/programs/prime-a-la-conversion.yaml
@@ -14,6 +14,7 @@ opérateur de contact: ASP
 url: ''
 nature de l'aide: financement
 montant du financement: jusqu’à 9 000 €, selon le véhicule
+activable en autonomie: oui
 objectifs:
 - description: Vérifiez l'égibilité à la mise au rebut de votre vieux véhicule.
   liens:

--- a/packages/data/programs/renovation-energetique.yaml
+++ b/packages/data/programs/renovation-energetique.yaml
@@ -1,4 +1,4 @@
-titre: Crédit d'Impôt Rénovation Énergétique (CIRE)
+titre: Rénovation énergétique
 promesse: Bénéficiez d'un crédit d’impôt pour la rénovation énergétique de vos bâtiments
 description: Vous bénéficiez d’un crédit d’impôt pour la rénovation énergétique (travaux
   d’isolation, chauffe-eau solaire, pompe à chaleur, ventilation mécanique…) de vos

--- a/packages/data/programs/repar-acteurs.yaml
+++ b/packages/data/programs/repar-acteurs.yaml
@@ -23,6 +23,7 @@ url: https://www.artisanat.fr/nous-connaitre/vous-accompagner/reparacteurs
 nature de l'aide: accompagnement
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 1/2 journée
+activable en autonomie: oui
 objectifs:
 - description: Pour obtenir le label Répar'acteurs, créez un compte, complétez une
     charte d'engagement et chargez vos pièces justificatives. Vous recevrez dans les

--- a/packages/data/programs/trophees-crisalide-eco-activites.yaml
+++ b/packages/data/programs/trophees-crisalide-eco-activites.yaml
@@ -14,6 +14,7 @@ url: https://www.crisalide-ecoactivites.fr/
 nature de l'aide: accompagnement
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: Un parcours sur 3 mois
+activable en autonomie: oui
 objectifs:
 - description: Déposez votre candidature à l'appel à projets en complétant un formulaire
     en ligne.

--- a/packages/data/schemas/program-data-schema.json
+++ b/packages/data/schemas/program-data-schema.json
@@ -18,20 +18,27 @@
     "promesse": {
       "title": "Promesse, résumé court du dispositif",
       "description": "La promesse a pour objectif de :\n- résumer le dispositif de manière claire & simple en quelques mots\n- distinguer les offres les unes des autres.\n\nFormulation :\n- 6 à 12 mots.\n- La promesse commence par un verbe à l'impératif\n- rédigée sous l'angle du bénéfice utilisateur, s'adressant à lui par le pluriel de politesse \"vous\" \"votre entreprise\" \n- pas de point à la fin de la promesse (sauf point d'exclamation cf ex.2)",
-      "examples": ["Mesurez votre maturité écologique et créez un plan d’action personnalisé avec à un conseiller", "Rejoignez un réseau de professionnels de la réparation, devenez artisan Répar’acteurs !"],
+      "examples": [
+        "Mesurez votre maturité écologique et créez un plan d’action personnalisé avec à un conseiller",
+        "Rejoignez un réseau de professionnels de la réparation, devenez artisan Répar’acteurs !"
+      ],
       "type": "string"
     },
     "description": {
       "title": "Description courte de l'objectif du dispositif",
       "description": "Qu'est-ce que l'entreprise gagne à bénéficier de cette aide ?\n\nFormulation :\n- 15 à 40 mots\n- rédigée sous l'angle du bénéfice utilisateur, s'adressant à lui par le pluriel de politesse \"vous\" \"votre entreprise\"\n- La description courte est ponctuée par un point",
-      "examples": ["Bénéficiez des conseils d'un expert pour mesurer les émissions de gaz à effet de serre de votre entreprise, définissez un plan d’actions pour les réduire de manière durable, mettez en œuvre vos premières actions et valorisez-les.",
-        "Les Répar’acteurs référencent les professionnels de la réparation et du dépannage partout en France. Rejoignez le réseau et devenez un ambassadeur de l’économie circulaire auprès de vos clients et au sein de votre territoire."],
+      "examples": [
+        "Bénéficiez des conseils d'un expert pour mesurer les émissions de gaz à effet de serre de votre entreprise, définissez un plan d’actions pour les réduire de manière durable, mettez en œuvre vos premières actions et valorisez-les.",
+        "Les Répar’acteurs référencent les professionnels de la réparation et du dépannage partout en France. Rejoignez le réseau et devenez un ambassadeur de l’économie circulaire auprès de vos clients et au sein de votre territoire."
+      ],
       "type": "string"
     },
     "description longue": {
       "title": "Description longue du dispositif",
       "description": "- La description longue est facultative. Elle peut être ajoutée si on juge que l'utilisateur ne dispose pas des informations suffisantes avec les seules autres informations. Elle peut être ajoutée par exemple :\n- pour définir un terme technique\n- pour détailler une loi à laquelle un dispositif fait référence\n- pour détailler les projets concernés par un financement\n\nFormulation :\n- 15 à 100 mots",
-      "examples": ["La marque Imprim'vert® a pour objectif de favoriser la mise en place par les entreprises exerçant les activités d'impression, d'actions concrètes conduisant à une diminution des impacts de l'activité sur l'environnement.\nLe cahier des charges Imprim’Vert® est fondé sur cinq critères simples : la bonne gestion des déchets dangereux, la sécurisation de stockage des liquides dangereux, la non utilisation de certains produits CMR, la sensibilisation environnementale des salariés et de la clientèle, et le suivi des consommations énergétiques du site."],
+      "examples": [
+        "La marque Imprim'vert® a pour objectif de favoriser la mise en place par les entreprises exerçant les activités d'impression, d'actions concrètes conduisant à une diminution des impacts de l'activité sur l'environnement.\nLe cahier des charges Imprim’Vert® est fondé sur cinq critères simples : la bonne gestion des déchets dangereux, la sécurisation de stockage des liquides dangereux, la non utilisation de certains produits CMR, la sensibilisation environnementale des salariés et de la clientèle, et le suivi des consommations énergétiques du site."
+      ],
       "type": "string"
     },
     "thématiques": {
@@ -56,7 +63,11 @@
             "title": "Description de l'étape",
             "type": "string",
             "description": "Formulation :\n- les étapes sont à rédiger à l'impératif\n- rédigés sous l'angle du bénéfice utilisateur, s'adressant à lui par le pluriel de politesse \"vous\" \"votre entreprise\"\n- Elles sont ponctuées par un point.",
-            "examples": ["Mesurez les émissions de gaz à effet de serre de votre entreprise sur l'ensemble de votre chaîne de valeur (scopes 1, 2 et 3).", "Élaborez votre plan d'action pour décarboner votre activité.", "Mettez en place les premières actions de la conduite du changement au sein de votre entreprise (alignement des équipes, formation, communication, etc.) et avec vos principaux clients et fournisseurs."]
+            "examples": [
+              "Mesurez les émissions de gaz à effet de serre de votre entreprise sur l'ensemble de votre chaîne de valeur (scopes 1, 2 et 3).",
+              "Élaborez votre plan d'action pour décarboner votre activité.",
+              "Mettez en place les premières actions de la conduite du changement au sein de votre entreprise (alignement des équipes, formation, communication, etc.) et avec vos principaux clients et fournisseurs."
+            ]
           },
           "url étape": {
             "title": "URL d'une ressource utile pour l'étape",
@@ -106,12 +117,12 @@
     "début de validité": {
       "description": "Premier jour de validité de l'offre. Date au format JJ/MM/AAAA",
       "type": "string",
-      "pattern": "^[0-3][0-9]\/[0-1][0-9]\/[0-9]{4}$"
+      "pattern": "^[0-3][0-9]/[0-1][0-9]/[0-9]{4}$"
     },
     "fin de validité": {
       "description": "Dernier jour de validité de l'offre. Date au format JJ/MM/AAAA",
       "type": "string",
-      "pattern": "^[0-3][0-9]\/[0-1][0-9]\/[0-9]{4}$"
+      "pattern": "^[0-3][0-9]/[0-1][0-9]/[0-9]{4}$"
     },
     "url": {
       "title": "URL de la page présentant le dispositif",
@@ -139,14 +150,13 @@
     },
     "type de l'aide": {
       "description": "Précise s'il s'agit d'une aide financière, d'un accompagnement, ou d'un prêt, d'une formation ou d'un avantage fiscal. Un accompagnement se définit comme la réalisation d'une prestation intellectuelle, par un intervenant choisi par l'opérateur.",
-      "enum": [
-        "accompagnement",
-        "formation",
-        "financement",
-        "avantage fiscal",
-        "prêt"
-      ]
+      "enum": ["accompagnement", "formation", "financement", "avantage fiscal", "prêt"]
     },
+    "activable en autonomie": {
+      "description": "Précise s'il s'agit d'un dispositif en autonomie ou s'il y aura des interactions avec l'opérateur.",
+      "type": "string"
+    },
+
     "coût de l'accompagnement": {
       "description": "Uniquement si l'aide est de type \"accompagnement\". Le coût reste à charge correspond au montant que devra payer l'entreprise pour bénéficier d'un accompagnement, après déduction de la subvention.\n\n Formulation :\n- 10 mots max\n- selon le format \"x € HT après subvention de x%\"\n- écriture des chiffres en unités numériques\n- ne pas utiliser d'abréviations (ex : utiliser jour et non l'abréviation \"j.\")",
       "examples": ["4 000 € HT après subvention de 60%"],
@@ -226,7 +236,7 @@
         "secteur géographique": {
           "title": "Conditions d'éligibilité relatives au secteur géographique",
           "type": "object",
-          "default": {"description": ["France et territoires d'outre-mer"]},
+          "default": { "description": ["France et territoires d'outre-mer"] },
           "properties": {
             "description": {
               "title": "Description en langage naturel des conditions d'éligibilité relatives au secteur géographique",
@@ -278,7 +288,7 @@
         "taille de l'entreprise": {
           "type": "object",
           "title": "Conditions d'éligibilité relatives à la taille de l'entreprise",
-          "default": {"description": ["Toutes tailles"]},
+          "default": { "description": ["Toutes tailles"] },
           "properties": {
             "description": {
               "title": "Description en langage naturel des conditions d'éligibilité relatives à la taille de l'entreprise",
@@ -317,7 +327,7 @@
         "nombre d'années d'activité": {
           "type": "object",
           "title": "Conditions d'éligibilité relatives au nombre d'années d'activité",
-          "default": {"description": ["Éligible à toutes les entreprises"]},
+          "default": { "description": ["Éligible à toutes les entreprises"] },
           "properties": {
             "description": {
               "title": "Description en langage naturel des conditions d'éligibilité relatives au nombre d'années d'activité",

--- a/packages/data/schemas/program-data-schema.json
+++ b/packages/data/schemas/program-data-schema.json
@@ -156,7 +156,6 @@
       "description": "Précise s'il s'agit d'un dispositif en autonomie ou s'il y aura des interactions avec l'opérateur.",
       "type": "string"
     },
-
     "coût de l'accompagnement": {
       "description": "Uniquement si l'aide est de type \"accompagnement\". Le coût reste à charge correspond au montant que devra payer l'entreprise pour bénéficier d'un accompagnement, après déduction de la subvention.\n\n Formulation :\n- 10 mots max\n- selon le format \"x € HT après subvention de x%\"\n- écriture des chiffres en unités numériques\n- ne pas utiliser d'abréviations (ex : utiliser jour et non l'abréviation \"j.\")",
       "examples": ["4 000 € HT après subvention de 60%"],

--- a/packages/data/schemas/program-with-publicodes-schema.json
+++ b/packages/data/schemas/program-with-publicodes-schema.json
@@ -23,12 +23,12 @@
     "début de validité": {
       "description": "Premier jour de validité de l'offre. Date au format JJ/MM/AAAA",
       "type": "string",
-      "pattern": "^[0-3][0-9]\/[0-1][0-9]\/[0-9]{4}$"
+      "pattern": "^[0-3][0-9]/[0-1][0-9]/[0-9]{4}$"
     },
     "fin de validité": {
       "description": "Dernier jour de validité de l'offre. Date au format JJ/MM/AAAA",
       "type": "string",
-      "pattern": "^[0-3][0-9]\/[0-1][0-9]\/[0-9]{4}$"
+      "pattern": "^[0-3][0-9]/[0-1][0-9]/[0-9]{4}$"
     },
     "url": {
       "description": "TODO",
@@ -82,13 +82,11 @@
     },
     "nature de l'aide": {
       "description": "Précise s'il s'agit d'une aide financière, d'un accompagnement, ou d'un prêt. Un accompagnement se définit comme la réalisation d'une prestation intellectuelle, par un intervenant choisi par l'opérateur.",
-      "enum": [
-        "accompagnement",
-        "formation",
-        "financement",
-        "avantage fiscal",
-        "prêt"
-      ]
+      "enum": ["accompagnement", "formation", "financement", "avantage fiscal", "prêt"]
+    },
+    "activable en autonomie": {
+      "description": "Précise s'il s'agit d'un dispositif en autonomie ou s'il y aura des interactions avec l'opérateur.",
+      "type": "string"
     },
     "coût de l'accompagnement": {
       "description": "Uniquement pour les accompagnements. Ce champ est utile et requis uniquement si l'aide est de nature \"accompagnement\". Elle précise le coût reste à charge de l'utilisateur pour bénéficier de l'accompagnement. Il s'agit d'un champ texte, à des fins d'affichage.",

--- a/packages/data/tools/XL2yaml/XL2yaml.py
+++ b/packages/data/tools/XL2yaml/XL2yaml.py
@@ -105,6 +105,9 @@ def assembleProgramYAML(rawData, colNumbersByName, id):
     if nat == "avantage fiscal":
         set("montant de l'avantage fiscal", get("💰 Montant de l'aide"))
 
+    if get("Dispositif activable en autonomie") == 1:
+        set("activable en autonomie", "oui")
+
     objectives = createYamlObjectives(get_maybe)
     set("objectifs", objectives)
 

--- a/packages/web/src/components/program/detail/ProgramDetail.vue
+++ b/packages/web/src/components/program/detail/ProgramDetail.vue
@@ -54,7 +54,7 @@
     <div class="fr-grid-row fr-grid-row-gutters">
       <div class="fr-col">
         <!-- PROGRAM DETAILS -->
-        <div class="fr-grid-row fr-grid-row--gutters fr-mb-8v">
+        <div class="fr-grid-row fr-grid-row--gutters fr-mb-12v">
           <!-- IMAGE -->
           <div class="fr-col-md-4 fr-col-lg-3 fr-col-xl-3 fr-col-sm-12 fr-text-right fr-tee-program-detail-img">
             <img
@@ -92,6 +92,15 @@
               v-if="program"
               :program="program"
             ></ProgramObjective>
+            <DsfrButton
+              v-if="programNonAutonomy"
+              size="lg"
+              icon="fr-icon-mail-line"
+              class="fr-ml-md-3v"
+              :on-click="scrollToProgramForm"
+            >
+              {{ Translation.t('program.CTAButton') }}
+            </DsfrButton>
           </div>
         </div>
 
@@ -295,6 +304,12 @@ const columnTiles = computed(() => {
   const colsSize = Math.round(12 / infoBlocks.length)
   return `fr-col fr-col-xs-12 fr-col-sm-12 fr-col-md-${colsSize} fr-tee-detail-info-tile`
 })
+const programNonAutonomy = computed(() => {
+  if (program.value?.[`activable en autonomie`] == 'oui') {
+    return false
+  }
+  return true
+})
 
 // functions
 const resetDetailResult = async () => {
@@ -315,4 +330,10 @@ onBeforeMount(() => {
 const programIsAvailable = computed(() => {
   return Program.isAvailable(programsStore.currentProgram)
 })
+
+const scrollToProgramForm = () => {
+  if (TeeProgramFormContainer.value) {
+    TeeProgramFormContainer.value.scrollIntoView({ behavior: 'smooth' })
+  }
+}
 </script>

--- a/packages/web/src/components/program/detail/ProgramDetail.vue
+++ b/packages/web/src/components/program/detail/ProgramDetail.vue
@@ -93,7 +93,7 @@
               :program="program"
             ></ProgramObjective>
             <DsfrButton
-              v-if="programNonAutonomy"
+              v-if="!isProgramAutonomous"
               size="lg"
               icon="fr-icon-mail-line"
               class="fr-ml-md-3v"
@@ -304,11 +304,11 @@ const columnTiles = computed(() => {
   const colsSize = Math.round(12 / infoBlocks.length)
   return `fr-col fr-col-xs-12 fr-col-sm-12 fr-col-md-${colsSize} fr-tee-detail-info-tile`
 })
-const programNonAutonomy = computed(() => {
+const isProgramAutonomous = computed(() => {
   if (program.value?.[`activable en autonomie`] == 'oui') {
-    return false
+    return true
   }
-  return true
+  return false
 })
 
 // functions

--- a/packages/web/src/components/program/detail/ProgramForm.vue
+++ b/packages/web/src/components/program/detail/ProgramForm.vue
@@ -15,14 +15,7 @@
   >
     <!-- FORM LABEL -->
     <h3 class="fr-text-center">
-      {{
-        Format.capitalize(
-          Translation.t('program.form.label', {
-            prefixAide: findPrefix(program["nature de l'aide"], 'this'),
-            natureAide: program["nature de l'aide"]
-          }) || ''
-        )
-      }}
+      {{ Format.capitalize(Translation.t('program.form.label') || '') }}
     </h3>
     <!-- FORM HINT -->
     <p class="fr-text-center fr-pb-10v">
@@ -295,10 +288,6 @@ SIRET : ${siretValue}`
   }
 
   return ''
-}
-
-const findPrefix = (str: string, prefixCode: string = 'of') => {
-  return Translation.t(`articles.${str}.${prefixCode}`)
 }
 
 const updateOpportunityForm = (ev: string | boolean, id: string) => {

--- a/packages/web/src/components/program/detail/ProgramObjective.vue
+++ b/packages/web/src/components/program/detail/ProgramObjective.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="fr-mb-0v fr-mb-md-12v fr-mr-4v fr-mr-md-0">
+  <div class="fr-mb-0v fr-mb-md-6v fr-mr-4v fr-mr-md-0">
     <h3>
       {{ getProgramObjectiveTitle() }}
     </h3>

--- a/packages/web/src/pages/TeeCatalogPage.vue
+++ b/packages/web/src/pages/TeeCatalogPage.vue
@@ -5,5 +5,15 @@
   >
     <router-view />
   </div>
-  <ContactHelp />
+  <ContactHelp v-if="isCatalogRoot" />
 </template>
+
+<script setup lang="ts">
+import { useNavigationStore } from '@/stores/navigation'
+import { RouteName } from '@/types/routeType'
+
+const navigationStore = useNavigationStore()
+const isCatalogRoot = computed(() => {
+  return navigationStore.isByRouteName(RouteName.Catalog)
+})
+</script>

--- a/packages/web/src/translations/fr/program.ts
+++ b/packages/web/src/translations/fr/program.ts
@@ -8,6 +8,7 @@ const programFrDict = {
       }
     },
     programProviders: 'Contact',
+    CTAButton: 'Contactez un conseiller',
     programType: "Nature de l'aide",
     programEndValidity: 'Date de fin',
     programAvailable: 'Aide disponible',
@@ -18,7 +19,7 @@ const programFrDict = {
     programKnowMore: 'En savoir plus',
     programAmIEligible: 'Suis-je éligible ?',
     form: {
-      label: '{prefixAide} {natureAide} vous intéresse ?',
+      label: 'Contactez un conseiller',
       hint: '👋 Envoyez votre demande, un conseiller {operator} vous contactera prochainement',
       needs: `Bonjour,
 

--- a/packages/web/src/types/program/programTypes.ts
+++ b/packages/web/src/types/program/programTypes.ts
@@ -26,6 +26,7 @@ export interface ProgramData {
   'opérateur de contact': string
   'autres opérateurs'?: string[]
   "nature de l'aide": ProgramAidType
+  'activable en autonomie'?: string
   "coût de l'accompagnement"?: string
   "durée de l'accompagnement"?: string
   'montant du financement'?: string


### PR DESCRIPTION
- Ajoute un CTA "contactez un conseiller" qui renvoie vers le formulaire de contact (scroll en bas de page) pour tous les dispositifs sauf ceux "activables en autonomie.
  - ajoute un champ "activable en autonomie" dans les programmes
  - ajoute un bouton en fonctionation de la présence ou non du champ dans le programme affiché
- Change le titre du formulaire de contact en "contactez un conseiller
- enleve le bandeau en bas de page "nous contacter" de toutes les fiches dispositifs de l'annuaire

RAS sur l'implem, modifications qui touchent peu à la logique.

Un dispositif non autonome : https://tee-preprod-pr715.osc-fr1.scalingo.io/aides-entreprise/amo-chaufferie-biomasse
Un dispositif autonome : https://tee-preprod-pr715.osc-fr1.scalingo.io/aides-entreprise/extreme-defi-mobilite
