### PR TITLE
fix: establishment search now works with a SIREN search

### DIFF
--- a/packages/backend/src/establishment/domain/establishmentFeatures.ts
+++ b/packages/backend/src/establishment/domain/establishmentFeatures.ts
@@ -16,7 +16,8 @@ export default class EstablishmentFeatures {
 
   public async search(query: string): Promise<Result<EstablishmentSearch, Error>> {
     if (Validator.validateSiret(query)) {
-      return await this._searchBySiret(query)
+      const bySiretResult = await this._searchBySiret(query)
+      if (bySiretResult.isOk) return bySiretResult
     }
     return await this._searchByQuery(query)
   }

--- a/packages/common/src/establishment/validator.ts
+++ b/packages/common/src/establishment/validator.ts
@@ -2,6 +2,7 @@ export default class Validator {
   static validateSiret = (siret: string): boolean => {
     const trimmed = String(siret).replace(/[\s]/g, '')
     const length = trimmed.length
+    if (length != 14) return false
 
     let calc,
       calc2,

--- a/packages/web/src/components/track/form/TrackSiret.vue
+++ b/packages/web/src/components/track/form/TrackSiret.vue
@@ -177,7 +177,7 @@ const processInput = async () => {
     const searchResult = await new EstablishmentApi().get(queryValue.value)
 
     if (searchResult.isErr) {
-      errorMessage.value = Translation.t('enterprise.noStructureFound')
+      errorMessage.value = Translation.t('enterprise.apiError')
     } else if (searchResult.value.resultCount == 0) {
       errorMessage.value = Translation.t('enterprise.noStructureFound')
     } else {

--- a/packages/web/src/service/api/establishmentApi.ts
+++ b/packages/web/src/service/api/establishmentApi.ts
@@ -10,7 +10,6 @@ export default class EstablishmentApi extends RequestApi {
     try {
       const response = await fetch(url)
       if (!response.ok) {
-        console.log(`HTTP Error in establishement search API, ${response.status} - ${response.statusText}`)
         return Result.err(new Error())
       }
       return Result.ok((await response.json()) as EstablishmentSearch)

--- a/packages/web/src/service/api/establishmentApi.ts
+++ b/packages/web/src/service/api/establishmentApi.ts
@@ -9,6 +9,10 @@ export default class EstablishmentApi extends RequestApi {
     const url: string = this.url + query
     try {
       const response = await fetch(url)
+      if (!response.ok) {
+        console.log(`HTTP Error in establishement search API, ${response.status} - ${response.statusText}`)
+        return Result.err(new Error())
+      }
       return Result.ok((await response.json()) as EstablishmentSearch)
     } catch (error: unknown) {
       return Result.err(error as Error)

--- a/packages/web/src/translations/fr.ts
+++ b/packages/web/src/translations/fr.ts
@@ -73,6 +73,8 @@ export const frDict = {
   enterprise: {
     select: 'Sélectionnez votre entreprise',
     noStructureFound: "Aucune structure n'a été trouvée.",
+    apiError:
+      'Une erreur est survenue lors de la recherche. Veuillez essayer de nouveau en renseignant les 14 chiffres de votre numéro SIRET.',
     searchTooShort: '3 caractères minimums.',
     structureSize: {
       EI: 'Entreprise individuelle',


### PR DESCRIPTION
Fix le validator SIRET qui laissait passer les SIREN ce qui causait l'erreur dans le backend.
Fix la gestion des erreurs du back dans le front (J'ai repris du code déjà présent dans l'api program du front et pensais naivement que c'était géré par le try catch)
Utilise l'api recherche-entreprise comme fallback en cas d'erreur de l'api sirene pour ajouter une couche de robustesse.

close #741 
