### PR TITLE
chore: update vite server config to enable firefox vue dev tool usage

### DIFF
--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -79,13 +79,14 @@ const viteServer: ServerOptions = {
       secure: false
     }
   },
-  headers: buildHeaders()
+  headers: mode === 'development' ? buildDevHeaders() : buildHeaders()
 }
 
 export default defineConfig({
   server: viteServer,
   plugins: [plugins()],
   build: currentConfig,
+
   define: {
     'process.env': process.env
   },
@@ -108,6 +109,14 @@ function getSentryData(): { domain: string; url: string } | undefined {
     domain: `https://${host}${path}`,
     url: `https://${host}${path}/api/${projectId}/security/?sentry_key=${dsnComponents.publicKey}`
   }
+}
+
+function buildDevHeaders(): Record<string, string> {
+  const headers = buildHeaders()
+
+  headers['Content-Security-Policy'] = "script-src 'self' 'unsafe-eval'; " + headers['Content-Security-Policy']
+
+  return headers
 }
 
 function buildHeaders() {

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -79,7 +79,7 @@ const viteServer: ServerOptions = {
       secure: false
     }
   },
-  headers: mode === 'development' ? buildDevHeaders() : buildHeaders()
+  headers: buildHeaders()
 }
 
 export default defineConfig({
@@ -111,14 +111,6 @@ function getSentryData(): { domain: string; url: string } | undefined {
   }
 }
 
-function buildDevHeaders(): Record<string, string> {
-  const headers = buildHeaders()
-
-  headers['Content-Security-Policy'] = "script-src 'self' 'unsafe-eval'; " + headers['Content-Security-Policy']
-
-  return headers
-}
-
 function buildHeaders() {
   const sentryData = getSentryData()
   const headers: Record<string, string> = {
@@ -146,6 +138,10 @@ function buildHeaders() {
     // headers['Content-Security-Policy'] += `report-uri ${sentryData.url};`
     // headers['Public-Key-Pins'] = `default-src 'self' ${sentryData.domain};` + `report-uri ${sentryData.url};`
     headers['Expect-CT'] = `default-src 'self' ${sentryData.domain};` + `report-uri ${sentryData.url};`
+  }
+
+  if (mode === 'development') {
+    headers['Content-Security-Policy'] = "script-src 'self' 'unsafe-eval'; " + headers['Content-Security-Policy']
   }
 
   return headers


### PR DESCRIPTION
- ajout d'une directive CSP pour l'environnement de développement, permettant l'utilisation de l'extension vue dev tool sur firefox