### PR TITLE
improve: Use specific head title and meta description when a program is displayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2868,6 +2868,58 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
     },
+    "node_modules/@unhead/dom": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.9.11.tgz",
+      "integrity": "sha512-mg8DuqPcm+JWSN3SIPa9lbNtFhdQ1M7K2TJe8icI4bK56GSj4eUgJZrbphZAUWPAUAS1UFyFFGJG7N9Y31LKOw==",
+      "dependencies": {
+        "@unhead/schema": "1.9.11",
+        "@unhead/shared": "1.9.11"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/schema": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.9.11.tgz",
+      "integrity": "sha512-hvIGl20wpQQImyHvAMv2tPgccKLGEwMn8KYQdImUkiCLdQw2Jw9jH7syE/u+TPSqwOQIwsvPja5sK+SChL1KNw==",
+      "dependencies": {
+        "hookable": "^5.5.3",
+        "zhead": "^2.2.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/shared": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.9.11.tgz",
+      "integrity": "sha512-jgpQ/cPfXzQA7c4F4PKyPXxS9POXAMrJ0QUBMTQYNOW6t6KlljjK89n6nUEmGuiyO4jdJGooZNVS1fXVaKIgYQ==",
+      "dependencies": {
+        "@unhead/schema": "1.9.11"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/vue": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.9.11.tgz",
+      "integrity": "sha512-7gCEJGTSnpLcHGQ2j/IsBTz2nIUWbTlqUbbNiwPFgEksJbh8Pz8WduTvLC4ANlnnFy6PDG7yrZcaKJMOrNruoQ==",
+      "dependencies": {
+        "@unhead/schema": "1.9.11",
+        "@unhead/shared": "1.9.11",
+        "hookable": "^5.5.3",
+        "unhead": "1.9.11"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=2.7 || >=3"
+      }
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz",
@@ -6882,6 +6934,11 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -12997,6 +13054,20 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
+    "node_modules/unhead": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.9.11.tgz",
+      "integrity": "sha512-AoX0hOBrpYM5ctX3rNPaKeHkhybIMrrirb+NlonRBMHy/YkodO5m6mretYEe17bu9mQoeU2rnEWRm36MXtG4OQ==",
+      "dependencies": {
+        "@unhead/dom": "1.9.11",
+        "@unhead/schema": "1.9.11",
+        "@unhead/shared": "1.9.11",
+        "hookable": "^5.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/unimport": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/unimport/-/unimport-3.7.1.tgz",
@@ -14549,6 +14620,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zhead": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/zhead/-/zhead-2.2.4.tgz",
+      "integrity": "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "packages/backend": {
       "name": "@tee/backend",
       "version": "1.0.0",
@@ -14634,6 +14713,7 @@
         "@gouvminint/vue-dsfr": "^5.11.0",
         "@sentry/utils": "^7.99.0",
         "@sentry/vue": "^7.93.0",
+        "@unhead/vue": "^1.9.11",
         "@vitejs/plugin-vue": "^5.0.4",
         "@vue/tsconfig": "^0.5.1",
         "fs": "^0.0.1-security",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       ],
       "dependencies": {
         "@tsconfig/node20": "^20.1.4",
-        "chart.js": "^4.4.2",
         "concurrently": "^8.2.0",
         "dotenv": "^16.4.1",
         "true-myth": "^7.1.0",
@@ -14716,6 +14715,7 @@
         "@unhead/vue": "^1.9.11",
         "@vitejs/plugin-vue": "^5.0.4",
         "@vue/tsconfig": "^0.5.1",
+        "chart.js": "^4.4.2",
         "fs": "^0.0.1-security",
         "iframe-resizer": "^4.3.9",
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   },
   "dependencies": {
     "@tsconfig/node20": "^20.1.4",
-    "chart.js": "^4.4.2",
     "dotenv": "^16.4.1",
     "true-myth": "^7.1.0",
     "typescript": "^5.4.3",

--- a/packages/web/.eslintrc-auto-import.json
+++ b/packages/web/.eslintrc-auto-import.json
@@ -71,6 +71,14 @@
     "watch": true,
     "watchEffect": true,
     "watchPostEffect": true,
-    "watchSyncEffect": true
+    "watchSyncEffect": true,
+    "getActiveHead": true,
+    "injectHead": true,
+    "useHead": true,
+    "useHeadSafe": true,
+    "useSeoMeta": true,
+    "useServerHead": true,
+    "useServerHeadSafe": true,
+    "useServerSeoMeta": true
   }
 }

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -4,8 +4,6 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Transition écologique - Aides et financements TPE & PME</title>
-    <meta name="description" content="Service public pour les entreprises : Accédez simplement aux aides, accompagnements et financements pour réduire votre impact environnemental.">
     <!-- Open Graph meta data -->
     <meta data-rh="true" property="og:url" content="https://mission-transition-ecologique.beta.gouv.fr/">
     <meta data-rh="true" property="og:type" content="website">

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -56,7 +56,9 @@
     "vitest": "^1.2.1",
     "vue": "^3.2.47",
     "vue-router": "^4.2.5",
-    "tsx": "^4.7.2"
+    "tsx": "^4.7.2",
+    "chart.js": "^4.4.2",
+    "@unhead/vue": "^1.9.11"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.2.0",

--- a/packages/web/src/WebApp.vue
+++ b/packages/web/src/WebApp.vue
@@ -27,7 +27,6 @@
 import { onBeforeMount, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useNavigationStore } from './stores/navigation'
-import { useHead } from '@unhead/vue'
 
 import TeeHeader from './components/TeeHeader.vue'
 import TeeMatomo from './components/TeeMatomo.vue'

--- a/packages/web/src/WebApp.vue
+++ b/packages/web/src/WebApp.vue
@@ -27,6 +27,7 @@
 import { onBeforeMount, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useNavigationStore } from './stores/navigation'
+import { useHead } from '@unhead/vue'
 
 import TeeHeader from './components/TeeHeader.vue'
 import TeeMatomo from './components/TeeMatomo.vue'
@@ -50,5 +51,16 @@ onMounted(async () => {
   await router.isReady()
   navigationStore.setRouter(router)
   navigationStore.setRoute(route)
+})
+
+useHead({
+  title: 'Transition écologique - Aides et financements TPE & PME',
+  meta: [
+    {
+      name: 'description',
+      content:
+        'Service public pour les entreprises : Accédez simplement aux aides, accompagnements et financements pour réduire votre impact environnemental.'
+    }
+  ]
 })
 </script>

--- a/packages/web/src/auto-imports.d.ts
+++ b/packages/web/src/auto-imports.d.ts
@@ -14,10 +14,12 @@ declare global {
   const defineAsyncComponent: typeof import('vue')['defineAsyncComponent']
   const defineComponent: typeof import('vue')['defineComponent']
   const effectScope: typeof import('vue')['effectScope']
+  const getActiveHead: typeof import('@unhead/vue')['getActiveHead']
   const getCurrentInstance: typeof import('vue')['getCurrentInstance']
   const getCurrentScope: typeof import('vue')['getCurrentScope']
   const h: typeof import('vue')['h']
   const inject: typeof import('vue')['inject']
+  const injectHead: typeof import('@unhead/vue')['injectHead']
   const isProxy: typeof import('vue')['isProxy']
   const isReactive: typeof import('vue')['isReactive']
   const isReadonly: typeof import('vue')['isReadonly']
@@ -56,10 +58,16 @@ declare global {
   const useAttrs: typeof import('vue')['useAttrs']
   const useCssModule: typeof import('vue')['useCssModule']
   const useCssVars: typeof import('vue')['useCssVars']
+  const useHead: typeof import('@unhead/vue')['useHead']
+  const useHeadSafe: typeof import('@unhead/vue')['useHeadSafe']
   const useLink: typeof import('vue-router')['useLink']
   const useRoute: typeof import('vue-router')['useRoute']
   const useRouter: typeof import('vue-router')['useRouter']
   const useScheme: typeof import('@gouvminint/vue-dsfr')['useScheme']
+  const useSeoMeta: typeof import('@unhead/vue')['useSeoMeta']
+  const useServerHead: typeof import('@unhead/vue')['useServerHead']
+  const useServerHeadSafe: typeof import('@unhead/vue')['useServerHeadSafe']
+  const useServerSeoMeta: typeof import('@unhead/vue')['useServerSeoMeta']
   const useSlots: typeof import('vue')['useSlots']
   const useTabs: typeof import('@gouvminint/vue-dsfr')['useTabs']
   const watch: typeof import('vue')['watch']
@@ -87,10 +95,12 @@ declare module 'vue' {
     readonly defineAsyncComponent: UnwrapRef<typeof import('vue')['defineAsyncComponent']>
     readonly defineComponent: UnwrapRef<typeof import('vue')['defineComponent']>
     readonly effectScope: UnwrapRef<typeof import('vue')['effectScope']>
+    readonly getActiveHead: UnwrapRef<typeof import('@unhead/vue')['getActiveHead']>
     readonly getCurrentInstance: UnwrapRef<typeof import('vue')['getCurrentInstance']>
     readonly getCurrentScope: UnwrapRef<typeof import('vue')['getCurrentScope']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
     readonly inject: UnwrapRef<typeof import('vue')['inject']>
+    readonly injectHead: UnwrapRef<typeof import('@unhead/vue')['injectHead']>
     readonly isProxy: UnwrapRef<typeof import('vue')['isProxy']>
     readonly isReactive: UnwrapRef<typeof import('vue')['isReactive']>
     readonly isReadonly: UnwrapRef<typeof import('vue')['isReadonly']>
@@ -129,10 +139,16 @@ declare module 'vue' {
     readonly useAttrs: UnwrapRef<typeof import('vue')['useAttrs']>
     readonly useCssModule: UnwrapRef<typeof import('vue')['useCssModule']>
     readonly useCssVars: UnwrapRef<typeof import('vue')['useCssVars']>
+    readonly useHead: UnwrapRef<typeof import('@unhead/vue')['useHead']>
+    readonly useHeadSafe: UnwrapRef<typeof import('@unhead/vue')['useHeadSafe']>
     readonly useLink: UnwrapRef<typeof import('vue-router')['useLink']>
     readonly useRoute: UnwrapRef<typeof import('vue-router')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router')['useRouter']>
     readonly useScheme: UnwrapRef<typeof import('@gouvminint/vue-dsfr')['useScheme']>
+    readonly useSeoMeta: UnwrapRef<typeof import('@unhead/vue')['useSeoMeta']>
+    readonly useServerHead: UnwrapRef<typeof import('@unhead/vue')['useServerHead']>
+    readonly useServerHeadSafe: UnwrapRef<typeof import('@unhead/vue')['useServerHeadSafe']>
+    readonly useServerSeoMeta: UnwrapRef<typeof import('@unhead/vue')['useServerSeoMeta']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
     readonly useTabs: UnwrapRef<typeof import('@gouvminint/vue-dsfr')['useTabs']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>
@@ -153,10 +169,12 @@ declare module '@vue/runtime-core' {
     readonly defineAsyncComponent: UnwrapRef<typeof import('vue')['defineAsyncComponent']>
     readonly defineComponent: UnwrapRef<typeof import('vue')['defineComponent']>
     readonly effectScope: UnwrapRef<typeof import('vue')['effectScope']>
+    readonly getActiveHead: UnwrapRef<typeof import('@unhead/vue')['getActiveHead']>
     readonly getCurrentInstance: UnwrapRef<typeof import('vue')['getCurrentInstance']>
     readonly getCurrentScope: UnwrapRef<typeof import('vue')['getCurrentScope']>
     readonly h: UnwrapRef<typeof import('vue')['h']>
     readonly inject: UnwrapRef<typeof import('vue')['inject']>
+    readonly injectHead: UnwrapRef<typeof import('@unhead/vue')['injectHead']>
     readonly isProxy: UnwrapRef<typeof import('vue')['isProxy']>
     readonly isReactive: UnwrapRef<typeof import('vue')['isReactive']>
     readonly isReadonly: UnwrapRef<typeof import('vue')['isReadonly']>
@@ -195,10 +213,16 @@ declare module '@vue/runtime-core' {
     readonly useAttrs: UnwrapRef<typeof import('vue')['useAttrs']>
     readonly useCssModule: UnwrapRef<typeof import('vue')['useCssModule']>
     readonly useCssVars: UnwrapRef<typeof import('vue')['useCssVars']>
+    readonly useHead: UnwrapRef<typeof import('@unhead/vue')['useHead']>
+    readonly useHeadSafe: UnwrapRef<typeof import('@unhead/vue')['useHeadSafe']>
     readonly useLink: UnwrapRef<typeof import('vue-router')['useLink']>
     readonly useRoute: UnwrapRef<typeof import('vue-router')['useRoute']>
     readonly useRouter: UnwrapRef<typeof import('vue-router')['useRouter']>
     readonly useScheme: UnwrapRef<typeof import('@gouvminint/vue-dsfr')['useScheme']>
+    readonly useSeoMeta: UnwrapRef<typeof import('@unhead/vue')['useSeoMeta']>
+    readonly useServerHead: UnwrapRef<typeof import('@unhead/vue')['useServerHead']>
+    readonly useServerHeadSafe: UnwrapRef<typeof import('@unhead/vue')['useServerHeadSafe']>
+    readonly useServerSeoMeta: UnwrapRef<typeof import('@unhead/vue')['useServerSeoMeta']>
     readonly useSlots: UnwrapRef<typeof import('vue')['useSlots']>
     readonly useTabs: UnwrapRef<typeof import('@gouvminint/vue-dsfr')['useTabs']>
     readonly watch: UnwrapRef<typeof import('vue')['watch']>

--- a/packages/web/src/components/program/detail/ProgramDetail.vue
+++ b/packages/web/src/components/program/detail/ProgramDetail.vue
@@ -262,11 +262,13 @@ import Program from '@/utils/program/program'
 import Translation from '@/utils/translation'
 import { computed, onBeforeMount, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+// import { useMeta } from 'vue-meta'
 
 const programsStore = useProgramStore()
 const navigationStore = useNavigationStore()
 const route = useRoute()
 const router = useRouter()
+// const { title, meta } = useMeta()
 
 const program = ref<ProgramType>()
 const TeeProgramFormContainer = ref<HTMLElement | null | undefined>(null)
@@ -289,6 +291,8 @@ const programDuration = computed(() => program.value?.[`durée de l'accompagneme
 const programLoanDuration = computed(() => program.value?.[`durée du prêt`])
 const programProvider = computed(() => program.value?.['opérateur de contact'])
 const programEndValidity = computed(() => program.value?.[`fin de validité`])
+const programPageTitle = computed(() => `Transition écologique - ${program.value?.[`titre`]}`)
+const programPageMeta = computed(() => program.value?.[`description`] || ' ')
 
 const columnTiles = computed(() => {
   const infoBlocks = [
@@ -326,6 +330,30 @@ onBeforeMount(() => {
   // analytics / send event
   Matomo.sendEvent('result_detail', route.name === RouteName.CatalogDetail ? 'show_detail_catalog' : 'show_detail', props.programId)
 })
+
+watch(programPageTitle, (newTitle) => {
+  document.title = newTitle
+})
+
+watch(programPageMeta, (newMeta) => {
+  let descriptionElement = document.querySelector('meta[name="description"]') as HTMLMetaElement
+  if (descriptionElement) {
+    descriptionElement.setAttribute('content', newMeta)
+  } else {
+    descriptionElement = document.createElement('meta')
+    descriptionElement.name = 'description'
+    descriptionElement.content = newMeta
+    document.getElementsByTagName('head')[0].appendChild(descriptionElement)
+  }
+})
+
+// title.value = programPageTitle
+// meta.value = [
+//   {
+//     name: 'description',
+//     content: programPageMeta
+//   }
+// ]
 
 const programIsAvailable = computed(() => {
   return Program.isAvailable(programsStore.currentProgram)

--- a/packages/web/src/components/program/detail/ProgramDetail.vue
+++ b/packages/web/src/components/program/detail/ProgramDetail.vue
@@ -262,13 +262,12 @@ import Program from '@/utils/program/program'
 import Translation from '@/utils/translation'
 import { computed, onBeforeMount, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-// import { useMeta } from 'vue-meta'
+import { useHead } from '@unhead/vue'
 
 const programsStore = useProgramStore()
 const navigationStore = useNavigationStore()
 const route = useRoute()
 const router = useRouter()
-// const { title, meta } = useMeta()
 
 const program = ref<ProgramType>()
 const TeeProgramFormContainer = ref<HTMLElement | null | undefined>(null)
@@ -291,7 +290,7 @@ const programDuration = computed(() => program.value?.[`durée de l'accompagneme
 const programLoanDuration = computed(() => program.value?.[`durée du prêt`])
 const programProvider = computed(() => program.value?.['opérateur de contact'])
 const programEndValidity = computed(() => program.value?.[`fin de validité`])
-const programPageTitle = computed(() => `Transition écologique - ${program.value?.[`titre`]}`)
+const programPageTitle = computed(() => `Transition écologique des TPE & PME - ${program.value?.[`titre`]}`)
 const programPageMeta = computed(() => program.value?.[`description`] || ' ')
 
 const columnTiles = computed(() => {
@@ -331,29 +330,15 @@ onBeforeMount(() => {
   Matomo.sendEvent('result_detail', route.name === RouteName.CatalogDetail ? 'show_detail_catalog' : 'show_detail', props.programId)
 })
 
-watch(programPageTitle, (newTitle) => {
-  document.title = newTitle
+useHead({
+  title: programPageTitle,
+  meta: [
+    {
+      name: 'description',
+      content: programPageMeta
+    }
+  ]
 })
-
-watch(programPageMeta, (newMeta) => {
-  let descriptionElement = document.querySelector('meta[name="description"]') as HTMLMetaElement
-  if (descriptionElement) {
-    descriptionElement.setAttribute('content', newMeta)
-  } else {
-    descriptionElement = document.createElement('meta')
-    descriptionElement.name = 'description'
-    descriptionElement.content = newMeta
-    document.getElementsByTagName('head')[0].appendChild(descriptionElement)
-  }
-})
-
-// title.value = programPageTitle
-// meta.value = [
-//   {
-//     name: 'description',
-//     content: programPageMeta
-//   }
-// ]
 
 const programIsAvailable = computed(() => {
   return Program.isAvailable(programsStore.currentProgram)

--- a/packages/web/src/components/program/detail/ProgramDetail.vue
+++ b/packages/web/src/components/program/detail/ProgramDetail.vue
@@ -262,7 +262,6 @@ import Program from '@/utils/program/program'
 import Translation from '@/utils/translation'
 import { computed, onBeforeMount, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { useHead } from '@unhead/vue'
 
 const programsStore = useProgramStore()
 const navigationStore = useNavigationStore()

--- a/packages/web/src/main.ts
+++ b/packages/web/src/main.ts
@@ -10,6 +10,7 @@ import { router } from '@/router'
 import WebApp from '@/WebApp.vue'
 import { addIcons } from '@/plugin/icons'
 import Sentry from '@/plugin/sentry'
+import { createHead } from '@unhead/vue'
 
 addIcons()
 
@@ -19,6 +20,8 @@ const app: App = createApp(WebApp as Component)
 
 Sentry.init(app)
 
+const head = createHead()
+app.use(head)
 app.use(store)
 app.use(router)
 app.mount('#app')

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -9,6 +9,7 @@ import Components from 'unplugin-vue-components/vite'
 import { dsnFromString } from '@sentry/utils'
 import * as dotenv from 'dotenv'
 import SEOPlugin from './plugin/SEO/index'
+import { unheadVueComposablesImports } from '@unhead/vue'
 
 dotenv.config()
 
@@ -43,7 +44,7 @@ const plugins = async () => {
     SEOPlugin(),
     AutoImport({
       include: [/\.[tj]sx?$/, /\.vue$/, /\.vue\?vue/],
-      imports: ['vue', 'vue-router', vueDsfrAutoimportPreset, ohVueIconAutoimportPreset],
+      imports: ['vue', 'vue-router', vueDsfrAutoimportPreset, ohVueIconAutoimportPreset, unheadVueComposablesImports],
       vueTemplate: true,
       dts: './src/auto-imports.d.ts',
       eslintrc: {


### PR DESCRIPTION
- Ajout du plugin unheadVue
- Déclaration des titles et meta description par défaut dans app.vue
- Déclaration des titles et meta personnalisés lors de l'affichage d'un programme. 

Test fonctionnel réalisé : 
- vérif des champs concernés sur la page d'accueil
- vérif des champs concernés lors de l'ouverture d'un programme via le catalogue
- vérifs des champs lors d'un retour sur la page d'accueil après ouverture d'un programme  (non trivial !)

close #666