### PR TITLE
Fix fonction de filtre par opérateur dans l'annuaire

### DIFF
--- a/packages/common/src/program/types.ts
+++ b/packages/common/src/program/types.ts
@@ -12,8 +12,10 @@ export enum ProgramOperatorType {
   BPI = 'Bpifrance',
   CCI = 'CCI',
   CMA = 'CMA',
-  DDFIP = 'DGFIP',
+  DDFIP = 'DDFIP',
   LAPOSTE = 'La Poste',
   MTES = 'Ministère de la Transition Écologique et Solidaire',
-  ORACE = 'ORACE'
+  ORACE = 'ORACE',
+  BREIZHFAB = 'Breizh Fab',
+  ECOCO2 = 'EcoCO2'
 }

--- a/packages/web/src/utils/program/programFilters.ts
+++ b/packages/web/src/utils/program/programFilters.ts
@@ -36,7 +36,11 @@ export default class ProgramFilter {
     if (!this.isValidFilterValues(programOperatorsSelected)) {
       return true
     }
-    return programOperatorsSelected.includes(program['opérateur de contact'])
+    const matchingOperators = programOperatorsSelected.filter((operator: ProgramOperatorType) =>
+      program['opérateur de contact'].includes(operator)
+    )
+    console.log(program['opérateur de contact'], programOperatorsSelected, matchingOperators)
+    return matchingOperators.length > 0
   }
 
   static filterProgramsByObjective(program: ProgramData, objectiveTypeSelected: PublicodeObjective) {

--- a/packages/web/src/utils/program/programFilters.ts
+++ b/packages/web/src/utils/program/programFilters.ts
@@ -39,7 +39,6 @@ export default class ProgramFilter {
     const matchingOperators = programOperatorsSelected.filter((operator: ProgramOperatorType) =>
       program['opérateur de contact'].includes(operator)
     )
-    console.log(program['opérateur de contact'], programOperatorsSelected, matchingOperators)
     return matchingOperators.length > 0
   }
 


### PR DESCRIPTION
- fix fonction de filtre par opérateur = on vérifie maintenant avec une comparaison partielle entre les opérateurs sélectionnés et l'opérateur de contact de chaque programme (pour valider le cas "CCI ou CMA") 
- ajout des opérateurs de contacts manquants 