### PR TITLE
delete stats spi, rename mailerService into Manager

### DIFF
--- a/packages/backend/src/opportunity/application/opportunityService.ts
+++ b/packages/backend/src/opportunity/application/opportunityService.ts
@@ -5,7 +5,7 @@ import { brevoRepository } from '../infrastructure/api/brevo/brevoDeal'
 import { addBrevoContact } from '../infrastructure/api/brevo/brevoContact'
 import { OperatorRepository } from '../../operator/domain/spi'
 import { BpiFrance } from '../../operator/infrastructure/api/bpi/bpiFrance'
-import { ContactRepository, MailerService, OpportunityRepository } from '../domain/spi'
+import { ContactRepository, MailerManager, OpportunityRepository } from '../domain/spi'
 import { ProgramRepository } from '../../program/domain/spi'
 import ProgramsJson from '../../program/infrastructure/programsJson'
 import BrevoMail from '../infrastructure/api/brevo/brevoMail'
@@ -48,7 +48,7 @@ export default class OpportunityService {
     return ProgramsJson.getInstance()
   }
 
-  private _getMailRepository(): MailerService {
+  private _getMailRepository(): MailerManager {
     return { sendReturnReceipt: new BrevoMail().sendReturnReceipt }
   }
 }

--- a/packages/backend/src/opportunity/domain/opportunityFeatures.ts
+++ b/packages/backend/src/opportunity/domain/opportunityFeatures.ts
@@ -1,5 +1,5 @@
 import { Maybe, Result } from 'true-myth'
-import type { ContactRepository, MailerService, OpportunityRepository } from './spi'
+import type { ContactRepository, MailerManager, OpportunityRepository } from './spi'
 import type { OpportunityId, Opportunity, ContactDetails } from './types'
 import OperatorFeatures from '../../operator/domain/operatorFeatures'
 import { OperatorRepository } from '../../operator/domain/spi'
@@ -13,14 +13,14 @@ export default class OpportunityFeatures {
   private readonly _opportunityRepository: OpportunityRepository
   private readonly _operatorRepositories: OperatorRepository[]
   private readonly _programRepository: ProgramRepository
-  private readonly _mailRepository: MailerService
+  private readonly _mailRepository: MailerManager
 
   constructor(
     contactRepository: ContactRepository,
     opportunityRepository: OpportunityRepository,
     operatorRepositories: OperatorRepository[],
     programRepository: ProgramRepository,
-    mailRepository: MailerService
+    mailRepository: MailerManager
   ) {
     this._contactRepository = contactRepository
     this._opportunityRepository = opportunityRepository

--- a/packages/backend/src/opportunity/domain/spi.ts
+++ b/packages/backend/src/opportunity/domain/spi.ts
@@ -12,6 +12,6 @@ export type OpportunityRepository = {
   readDates: () => Promise<Result<Date[], Error>>
 }
 
-export type MailerService = {
+export type MailerManager = {
   sendReturnReceipt: (opportunity: Opportunity, program: Program) => Promise<Maybe<Error> | void>
 }

--- a/packages/backend/src/opportunity/infrastructure/api/brevo/brevoMail.ts
+++ b/packages/backend/src/opportunity/infrastructure/api/brevo/brevoMail.ts
@@ -3,7 +3,7 @@ import { Maybe } from 'true-myth'
 import Config from '../../../../config'
 import { Program as ProgramType } from '../../../../program/domain/types/types'
 import Program from '../../../../../../common/src/program/program'
-import { MailerService } from '../../../domain/spi'
+import { MailerManager } from '../../../domain/spi'
 import { Opportunity } from '../../../domain/types'
 
 export default class BrevoMail {
@@ -14,7 +14,7 @@ export default class BrevoMail {
     this._api.setApiKey(TransactionalEmailsApiApiKeys.apiKey, Config.BREVO_API_TOKEN)
   }
 
-  sendReturnReceipt: MailerService['sendReturnReceipt'] = async (
+  sendReturnReceipt: MailerManager['sendReturnReceipt'] = async (
     opportunity: Opportunity,
     program: ProgramType
   ): Promise<Maybe<Error> | void> => {

--- a/packages/backend/src/statistics/domain/spi.ts
+++ b/packages/backend/src/statistics/domain/spi.ts
@@ -1,6 +1,0 @@
-import type { Result } from 'true-myth'
-import StatsData from '@tee/common/src/stats/types'
-
-export type StatisticsRepository = {
-  get: () => Promise<Result<StatsData, Error>>
-}

--- a/packages/backend/tests/opportunity/createOpportunity.test.ts
+++ b/packages/backend/tests/opportunity/createOpportunity.test.ts
@@ -1,5 +1,5 @@
 import { Maybe, Result } from 'true-myth'
-import { MailerService } from '../../src/opportunity/domain/spi'
+import { MailerManager } from '../../src/opportunity/domain/spi'
 import {
   ContactDetails,
   ContactId,
@@ -29,7 +29,7 @@ const dummyAddContact = (_contact: ContactDetails, _optIn: true): Promise<Result
   return Promise.resolve(Result.ok({ id: 1 }))
 }
 
-const dummyMailRepository: MailerService = {
+const dummyMailRepository: MailerManager = {
   sendReturnReceipt: async () => {
     emailReceiptSent = true
     return Promise.resolve(void 0)


### PR DESCRIPTION
Clarification de la structure du backend : 
- Les classes Services sont désormais uniquement réversées pour les classes qui coordonnent un sujet dans le backend = qui exposent l'interface du sujet et qui injecte les bonnes infrastructures.

- On supprime donc "service" du naming des infras.
Voici le récap du naming actuel des infras (définies dans les SPIs): 
- Repository => le plus fréquent,  lié à de la data, aux "bases" de données : ProgramRepository,  EstablishmentRepository (recherche d'entreprise),  ContactRepository, OpportunityRepository
- Mapping => pour CityToRegionMapping et NafMapping
- Manager => le plus générique, pour la transmission des opportunités vers des services extérieurs (place des entreprise et bpi, OperatorManager pour le moment mais OppourtunityHubManager dans la PR PDE); pour le MailerManager; pour la gestion des règles publicodes : RulesManager
- Provider => Pour CurrentDataProvider

Autre noms possibles non utilisés pour le moment : Gateway, Connector, Adapter, Handler...
N'hésitez pas à réagir sur le naming des éléments des SPIs :) 
C'est le moment de choisir des noms qui ont du sens pour tous. 


Autre :
- suppression du SPI, fichier qui définit les interfaces entre le domain et l'infra, dans la partie statistique du back puisqu'il n'y a pas d'infra mais uniquement des calls aux autres services du back ! 




close #801