### PR TITLE
fix: programs filters

### DIFF
--- a/packages/web/src/components/program/list/ProgramList.vue
+++ b/packages/web/src/components/program/list/ProgramList.vue
@@ -149,12 +149,12 @@ const hasObjectiveCard = computed(() => {
 })
 
 const objective = computed(() => {
-  if (programStore.hasObjectiveTypeSelected()) {
-    return programStore.programFilters.objectiveTypeSelected
-  }
-
   if (UsedTrack.isSpecificGoal() && UsedTrack.hasPriorityObjective()) {
     return Theme.getPublicodeObjectiveByObjective(UsedTrack.getPriorityObjective())
+  }
+
+  if (programStore.hasObjectiveTypeSelected()) {
+    return programStore.programFilters.objectiveTypeSelected
   }
 
   return ''

--- a/packages/web/src/router/routes.ts
+++ b/packages/web/src/router/routes.ts
@@ -34,7 +34,7 @@ export const routes = [
         path: '',
         name: RouteName.QuestionnaireStart,
         component: TeeQuestionnaire as Component,
-        beforeEnter: [Hook.resetUsedTrackStore, Hook.resetQueries],
+        beforeEnter: [Hook.resetUsedTrackStore, Hook.resetQueries, Hook.resetProgramFilters],
         props: { trackId: TrackId.QuestionnaireRoute }
       },
       {


### PR DESCRIPTION
- inversion de la priorité pour récupérer l'objective entre celui des filtres et des tracks
- `reset` des `programs filters` quand on commence un nouveau parcours

note: La PR fixe aussi l'issue https://github.com/betagouv/mission-transition-ecologique/issues/816