### PR TITLE
fix: update brevo status only if transmit is sucessfull 

### DIFF
--- a/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
+++ b/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
@@ -71,7 +71,7 @@ export default class OpportunityFeatures {
     void new OpportunityHubFeatures(this._opportunityHubRepositories)
       .maybeTransmitOpportunity(opportunity, program)
       .then(async (opportunityHubResult) => {
-        if (opportunityHubResult !== false) {
+        if (opportunityHubResult == Maybe.nothing()) {
           const opportunityUpdateErr = await this._updateOpportunitySentToHub(opportunityId, !opportunityHubResult.isJust)
           if (opportunityUpdateErr.isJust) {
             // TODO: Send notif: Opportunity not updated in our DB creating a missmatch between the status in the DB and the real opportunity status


### PR DESCRIPTION
Avec l'ancienne implem, on mettait à jour le statut même si la transmission retournait une erreur. 