### PR TITLE
feat: add sentry capture messages in the backend

### DIFF
--- a/apps/backend/src/controller/establishment/establishmentController.ts
+++ b/apps/backend/src/controller/establishment/establishmentController.ts
@@ -1,6 +1,7 @@
 import { Controller, Route, SuccessResponse, TsoaResponse, Res, Example, Get, Path } from 'tsoa'
 import { ErrorJSON, Establishment, EstablishmentNotFoundError, EstablishmentService, ValidateErrorJSON } from '@tee/backend-ddd'
 import { EstablishmentSearch } from '@tee/common'
+import * as Sentry from '@sentry/node'
 
 interface EstablishmentNotFoundErrorJSON {
   message: 'Establishment not found'
@@ -58,6 +59,7 @@ export class SireneController extends Controller {
 
     if (establishmentResult.isErr) {
       const err = establishmentResult.error
+      Sentry.captureMessage('Error in getEstablishmentBySiret, ' + query + ', '  + err, "error")
 
       if (err instanceof EstablishmentNotFoundError) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/apps/backend/src/controller/opportunity/opportunityController.ts
+++ b/apps/backend/src/controller/opportunity/opportunityController.ts
@@ -2,6 +2,7 @@ import { OpportunityBody } from '@tee/common'
 import { Body, Controller, Example, Post, Res, Route, SuccessResponse, TsoaResponse } from 'tsoa'
 import { Err } from 'true-myth/dist/es/result'
 import { ErrorJSON, OpportunityId, OpportunityService, ValidateErrorJSON, ServiceNotFoundError } from '@tee/backend-ddd'
+import * as Sentry from '@sentry/node'
 
 @SuccessResponse('200', 'OK')
 @Route('opportunities')
@@ -23,6 +24,7 @@ export class OpportunityController extends Controller {
     const opportunityResult = await new OpportunityService().createOpportunity(requestBody.opportunity, requestBody.optIn)
 
     if (opportunityResult.isErr) {
+      Sentry.captureMessage('Error in createOpportunity, ' + requestBody + ' ' + opportunityResult.error, "error")
       this.throwErrorResponse(opportunityResult, notFoundResponse, requestFailedResponse)
 
       return

--- a/apps/backend/src/controller/program/programsController.ts
+++ b/apps/backend/src/controller/program/programsController.ts
@@ -3,6 +3,7 @@ import { OpenAPISafeProgram } from './types'
 import { Err } from 'true-myth/dist/es/result'
 import { QuestionnaireData } from '@tee/common'
 import { ErrorJSON, ProgramService } from '@tee/backend-ddd'
+import * as Sentry from '@sentry/node'
 
 @SuccessResponse('200', 'OK')
 @Route('programs')
@@ -25,6 +26,7 @@ export class ProgramsController extends Controller {
     const programsResult = programService.getFilteredPrograms(questionnaireData)
 
     if (programsResult.isErr) {
+      Sentry.captureMessage('Error in get programs, ' + questionnaireData + ' ' + programsResult.error, "error")
       this.throwErrorResponse(programsResult, requestFailedResponse)
       return
     }
@@ -47,6 +49,7 @@ export class ProgramsController extends Controller {
 
     if (!program) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      Sentry.captureMessage('Error in get Program id, ' + programId, "error")
       return notFoundResponse(404, { message: `Program with id "${programId}" could not be found` })
     }
 

--- a/apps/backend/src/controller/statistics/statisticsController.ts
+++ b/apps/backend/src/controller/statistics/statisticsController.ts
@@ -1,6 +1,7 @@
 import { ErrorJSON, StatisticsService } from '@tee/backend-ddd'
 import { Controller, Get, Res, Route, SuccessResponse, TsoaResponse } from 'tsoa'
 import { StatsData } from '@tee/common'
+import * as Sentry from '@sentry/node'
 
 @SuccessResponse('200', 'OK')
 @Route('statistics')
@@ -10,15 +11,16 @@ export class StatisticsController extends Controller {
    */
   @Get()
   public async get(@Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>): Promise<StatsData> {
-    const opportunityResult = await new StatisticsService().get()
+    const statisticsResult = await new StatisticsService().get()
 
-    if (opportunityResult.isErr) {
-      const err = opportunityResult.error
+    if (statisticsResult.isErr) {
+      const err = statisticsResult.error
+      Sentry.captureMessage('Error in get statistics, ' + statisticsResult.error, "error")
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return requestFailedResponse(500, { message: `Server internal error: ${err.message}` })
     }
 
-    return opportunityResult.value
+    return statisticsResult.value
   }
 }

--- a/libs/backend-ddd/src/establishment/infrastructure/api/recherche-entreprise/recherche-entreprise.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/recherche-entreprise/recherche-entreprise.ts
@@ -4,6 +4,7 @@ import { Result } from 'true-myth'
 import { EstablishmentRepository } from '../../../domain/spi'
 import { ensureError } from '../../../../common/domain/error/errors'
 import { RechercheEntrepriseEstablishment, RechercheEntrepriseSearch } from './type'
+import * as Sentry from '@sentry/node'
 
 export class RechercheEntreprise {
   public searchEstablishment: EstablishmentRepository['search'] = async (query) => {
@@ -16,6 +17,7 @@ export class RechercheEntreprise {
       return Result.ok(establishmentList)
     } catch (err: unknown) {
       let error = ensureError(err)
+      Sentry.captureMessage('Error in recherche-entreprise get api call ' + query + ' ' + err, "error")
 
       if (error instanceof AxiosError) {
         if (error.response && error.response.status == 404) {

--- a/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
@@ -5,6 +5,7 @@ import { Result } from 'true-myth'
 import { EstablishmentRepository } from '../../../domain/spi'
 import AxiosHeaders from '../../../../common/infrastructure/api/axiosHeaders'
 import { ensureError } from '../../../../common/domain/error/errors'
+import * as Sentry from '@sentry/node'
 
 /**
  * getEstablishment reads the API token from an environment
@@ -32,6 +33,7 @@ export const requestSireneAPI = async (token: string, siret: string): Promise<Re
     return Result.ok(parseEstablishment(response.data))
   } catch (err: unknown) {
     let error = ensureError(err)
+      Sentry.captureMessage('Error in sirene get siret API call ' + siret + ' ' + err, "error")
 
     if (error instanceof AxiosError) {
       if (error.response && error.response.status == 404) {

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoContact.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoContact.ts
@@ -2,9 +2,10 @@ import { ContactId } from '../../../domain/types'
 import axios from 'axios'
 import { Result } from 'true-myth'
 import { ContactRepository } from '../../../domain/spi'
-import { BrevoCompanySize, ContactAttributes } from './types'
+import { BrevoCompanySize, BrevoPostContactPayload, ContactAttributes } from './types'
 import BrevoAPI from './brevoAPI'
 import { ContactDetails } from '@tee/common'
+import * as Sentry from '@sentry/node'
 
 const DEBUG_BREVO_LIST_ID = '4'
 
@@ -17,14 +18,16 @@ export const addBrevoContact: ContactRepository['createOrUpdate'] = async (conta
 }
 
 const requestCreateContact = async (listIds: number[], contact: ContactDetails, optIn: true): Promise<Result<ContactId, Error>> => {
-  const responseResult = await new BrevoAPI().PostContact({
+  const requestPayload : BrevoPostContactPayload = {
     email: contact.email,
     updateEnabled: true,
     listIds: listIds,
     attributes: convertDomainToBrevoContact(contact, optIn)
-  })
+  }
+  const responseResult = await new BrevoAPI().PostContact(requestPayload)
 
   if (responseResult.isErr) {
+    Sentry.captureMessage('Error in Brevo CreateContact api call ' + requestPayload + ' ' + responseResult.error, "error")
     return Result.err(responseResult.error)
   }
 
@@ -43,6 +46,11 @@ const requestCreateContact = async (listIds: number[], contact: ContactDetails, 
 
 const retrieveExistingContactId = async (email: string): Promise<Result<ContactId, Error>> => {
   const responseResult = await new BrevoAPI().GetContact(email)
+  if (responseResult.isErr) {
+    Sentry.captureMessage('Error in Brevo GetContact api call ' + email + ' ' + responseResult.error, "error")
+    return Result.err(responseResult.error)
+  }
+
   const contactId = responseResult.map((r) => r.data as ContactId)
   return contactId
 }

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -126,7 +126,7 @@ const getBrevoCreationDates = async (): Promise<Result<Date[], Error>> => {
 
   if (response.isOk) {
     const brevoDealResponse: BrevoDealResponse = response.value.data as BrevoDealResponse
-    if (!brevoDealResponse.items && brevoDealResponse.items.length === 0) {
+    if (!brevoDealResponse.items || brevoDealResponse.items.length === 0) {
       Sentry.captureMessage("Brevo deal list doesn't exist or is empty empty" + brevoDealResponse, "error")
       return Result.err(new Error("Brevo deal list doesn't exist or is empty empty"))
     }

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -13,6 +13,7 @@ import {
 import Config from '../../../../config'
 import { QuestionnaireRoute } from '@tee/common'
 import { Operators } from '@tee/data'
+import * as Sentry from '@sentry/node'
 
 // "Opportunities" are called "Deals" in Brevo
 
@@ -42,6 +43,11 @@ const requestCreateDeal = async (name: string, attributes: DealAttributes): Prom
     payload.attributes.pipeline = Config.BREVO_DEAL_PIPELINE
   }
   const responseResult = await new BrevoAPI().PostDeal(payload)
+  if (responseResult.isErr) {
+    Sentry.captureMessage('Error in Brevo PostDeal api call ' + payload + ' ' + responseResult.error, "error")
+    return Result.err(responseResult.error)
+  }
+
 
   const dealId = responseResult.map((r) => r.data as OpportunityId)
   return dealId
@@ -61,6 +67,10 @@ const requestUpdateDeal = async (dealId: OpportunityId, attributes: DealUpdateAt
     attributes: attributes
   })
 
+  if (responseResult.isErr){
+    Sentry.captureMessage('Error in Brevo PatchDeal api call ' + dealId.id + ' ' + attributes + ' ' + responseResult.error, "error")
+  }
+
   return Maybe.of(responseResult.isErr ? responseResult.error : null)
 }
 
@@ -72,7 +82,10 @@ const associateBrevoDealToContact = async (dealId: OpportunityId, contactId: num
     linkContactIds: [contactId]
   })
 
-  if (responsePatch.isErr) return Maybe.of(responsePatch.error)
+  if (responsePatch.isErr) {
+    Sentry.captureMessage('Error in Brevo LinkDeal (to contact) api call ' + dealIdStr + ' ' + contactId + ' ' + responsePatch.error, "error")
+    return Maybe.of(responsePatch.error)
+  }
   else return Maybe.nothing()
 }
 
@@ -113,11 +126,9 @@ const getBrevoCreationDates = async (): Promise<Result<Date[], Error>> => {
 
   if (response.isOk) {
     const brevoDealResponse: BrevoDealResponse = response.value.data as BrevoDealResponse
-    if (!brevoDealResponse.items) {
-      return Result.err(new Error('No Items field in Brevo API'))
-    }
-    if (brevoDealResponse.items.length === 0) {
-      return Result.err(new Error('Brevo deal list is empty'))
+    if (!brevoDealResponse.items && brevoDealResponse.items.length === 0) {
+      Sentry.captureMessage("Brevo deal list doesn't exist or is empty empty" + brevoDealResponse, "error")
+      return Result.err(new Error("Brevo deal list doesn't exist or is empty empty"))
     }
     const dateList: Date[] = []
     for (const deal of brevoDealResponse.items) {
@@ -126,6 +137,7 @@ const getBrevoCreationDates = async (): Promise<Result<Date[], Error>> => {
     }
     return Result.ok(dateList)
   } else {
+    Sentry.captureMessage("Error in brevo GetDeal api call, " + response.error, "error")
     return Result.err(response.error)
   }
 }
@@ -148,6 +160,7 @@ const getDailyOpportunitiesByContactId = async (contactId: number): Promise<Resu
     }
     return Result.ok(selectedDeals)
   } else {
+    Sentry.captureMessage("Error in brevo GetDeal api call, " + response.error, "error")
     return Result.err(response.error)
   }
 }

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoMail.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoMail.ts
@@ -4,6 +4,7 @@ import Config from '../../../../config'
 import { MailerManager } from '../../../domain/spi'
 import { ProgramType } from '@tee/data'
 import { Program, Opportunity } from '@tee/common'
+import * as Sentry from '@sentry/node'
 
 export default class BrevoMail {
   private readonly _templateReceipt = 11
@@ -20,6 +21,7 @@ export default class BrevoMail {
     try {
       await this._api.sendTransacEmail(this._email(opportunity, program))
     } catch (error: unknown) {
+      Sentry.captureMessage('Error in Brevo SendTransacEmail api call ' + this._email(opportunity, program) + ' ' + error, "error")
       return Maybe.just(error as Error)
     }
   }

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/bpiFrance.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/bpiFrance.ts
@@ -8,6 +8,7 @@ import opportunityPayloadDTO from './opportunityPayloadDTO'
 import Config from '../../../../config'
 import { Operators, ProgramType } from '@tee/data'
 import { Opportunity } from '@tee/common'
+import * as Sentry from '@sentry/node'
 
 export class BpiFrance extends OpportunityHubAbstract {
   protected _axios: AxiosInstance
@@ -38,6 +39,7 @@ export class BpiFrance extends OpportunityHubAbstract {
       })
       return Result.ok(response.data)
     } catch (exception: unknown) {
+      Sentry.captureMessage('Error in BPI getToken ' + exception, "error")
       return Result.err(handleException(exception))
     }
   }
@@ -56,9 +58,11 @@ export class BpiFrance extends OpportunityHubAbstract {
       if (response.data) {
         return Maybe.nothing()
       } else {
+        Sentry.captureMessage('Error creating an opportunity at BPI during BPI API Call ' + response, "error")
         return Maybe.of(new Error("Erreur à la création d'une opportunité chez BPI durant l'appel BPI. HTTP CODE:" + response.status))
       }
     } catch (exception: unknown) {
+      Sentry.captureMessage('Error creating an opportunity at BPI' + exception, "error")
       return Maybe.of(handleException(exception))
     }
   }

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -11,6 +11,8 @@ import OpportunityService from '../../../../opportunity/application/opportunityS
 import { Objective } from '../../../../common/types'
 import { Operators, ProgramType } from '@tee/data'
 import { Opportunity } from '@tee/common'
+import * as Sentry from '@sentry/node'
+
 export class PlaceDesEntreprises extends OpportunityHubAbstract {
   protected readonly _baseUrl = Config.PDE_API_BASEURL
   protected _axios: AxiosInstance
@@ -58,11 +60,13 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
       })
       const status = response.status
       if (status != 200) {
+        Sentry.captureMessage('Error creating an opportunity at CE during CE API Call ' + response, "error")
         return Maybe.of(Error('PDE Api Error ' + status))
       } else {
         return Maybe.nothing()
       }
     } catch (exception: unknown) {
+      Sentry.captureMessage('Error creating an opportunity at CE ' + exception, "error")
       return Maybe.of(handleException(exception))
     }
   }
@@ -71,7 +75,7 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
     const contact = opportunity.contactId
     const previousDailyOpportunities = await new OpportunityService().getDailyOpportunitiesByContactId(contact)
     if (previousDailyOpportunities.isErr) {
-      return false // TODO error handling
+      return false
     }
 
     let tranmismissiblePrograms = 0

--- a/libs/backend-ddd/src/statistics/domain/statisticsFeatures.ts
+++ b/libs/backend-ddd/src/statistics/domain/statisticsFeatures.ts
@@ -3,7 +3,7 @@ import { ProgramService } from '../../program/application/programService'
 import { Result } from 'true-myth'
 import { OpportunityRepository } from '../../opportunity/domain/spi'
 import StatisticsCache from './statisticsCache'
-
+import * as Sentry from '@sentry/node'
 export default class StatisticsFeatures {
   private readonly _opportunityRepository: OpportunityRepository
   private readonly _cache: StatisticsCache
@@ -52,6 +52,7 @@ export default class StatisticsFeatures {
     const allPrograms = this._programService.getAll()
     const activeProgramsResult = this._programService.getFilteredPrograms({})
     if (activeProgramsResult.isErr) {
+      Sentry.captureMessage('Error generating program statistics ' + activeProgramsResult.error, "error")
       throw activeProgramsResult.error
     }
     return {
@@ -106,9 +107,7 @@ export default class StatisticsFeatures {
     if (opportunitiesDates.isOk) {
       return opportunitiesDates.value
     }
-
-    console.log(opportunitiesDates.error)
-    // TODO: improve error handling
+    Sentry.captureMessage('Error generating Opportunities dates ' + opportunitiesDates.error, "error")
     return null
   }
 }


### PR DESCRIPTION
Comme discuté lors du séminaire à Angers, j'ai ajouté des logs sentry sur les retours d'erreurs sur nos controlleurs. 

Comme on utilise true-myth pour gérer les erreurs plus en amont dans le code, on a tendance à avoir, dans certains cas, juste un message d'erreur sans plus d'informations. 
Pour tenter d'obtenir plus d'infos, j'ai ajouté des messages d'erreur sur tous nos appels vers des API externes. 

Finalement, j'ai ajouté des messages d'erreurs au cours du process de la création d'opportunité parce qu'il y a de nombreuses étapes différentes qui peuvent causer les erreurs. Et j'ai fait la même chose sur les stats qui sont séparés en deux modules très distincts.

La pertinence de ces choix sera à voir dans les prochains mois dans sentry. 
ça me semble un premier pas vers un meilleur suivi des erreurs. 
N'hésitez pas à faire des remarques / retours. 