### PR TITLE
Fix: Renommage des thématiques Energie et rénovation

### DIFF
--- a/apps/web/src/utils/theme.ts
+++ b/apps/web/src/utils/theme.ts
@@ -13,7 +13,7 @@ export class Theme {
       color: Color.blue
     },
     {
-      title: 'Économies d’énergie',
+      title: 'Énergie',
       tagLabel: '⚡️ énergie',
       value: PublicodeObjective.EnergyPerformance,
       image: '/images/thematique/thematique-energie.svg',
@@ -28,7 +28,7 @@ export class Theme {
     },
     {
       title: 'Construction & rénovation',
-      tagLabel: '🏢 bâtiment',
+      tagLabel: '🏢 rénovation',
       value: PublicodeObjective.BuildingRenovation,
       image: '/images/thematique/thematique-batiments.svg',
       color: Color.blue


### PR DESCRIPTION
Changement du titre Economies d'énergie par Energie et changement du tag batiment par rénovation

