### PR TITLE
refactor: improve CI command to use nx

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -5,6 +5,13 @@
   "projectType": "application",
   "tags": [],
   "targets": {
+    "ci": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "lint",
+        "type-check"
+      ]
+    },
     "type-check": {
       "executor": "nx:run-commands",
       "dependsOn": [

--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -5,6 +5,13 @@
   "sourceRoot": "apps/web/src",
   "// targets": "to see all targets run: nx show project @tee/web --web",
   "targets": {
+    "ci": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "lint",
+        "type-check"
+      ]
+    },
     "build": {
       "dependsOn": [
         "generate-seo"

--- a/libs/backend-ddd/project.json
+++ b/libs/backend-ddd/project.json
@@ -5,5 +5,13 @@
   "projectType": "library",
   "tags": [],
   "// targets": "to see all targets run: nx show project @tee/backend-ddd --web",
-  "targets": {}
+  "targets": {
+    "ci": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "lint",
+        "test"
+      ]
+    }
+  }
 }

--- a/libs/common/project.json
+++ b/libs/common/project.json
@@ -5,5 +5,12 @@
   "projectType": "library",
   "tags": [],
   "// targets": "to see all targets run: nx show project @tee/common --web",
-  "targets": {}
+  "targets": {
+    "ci": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "lint"
+      ]
+    }
+  }
 }

--- a/libs/data/project.json
+++ b/libs/data/project.json
@@ -6,6 +6,13 @@
   "tags": [],
   "// targets": "to see all targets run: nx show project @tee/data --web",
   "targets": {
+    "ci": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "lint",
+        "test"
+      ]
+    },
     "generate-program": {
       "executor": "nx:run-commands",
       "options": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "nx run-many -t serve --verbose",
     "dev:start": "PORT=4242 npm run start",
-    "dev:build:start": "npm run build && npm run start:dev",
+    "dev:build:start": "npm run build && npm run dev:start",
     "build": "nx run-many -t build",
     "start": "nx run-many -t start --port $PORT",
     "generate:program": "nx run @tee/data:generate-program",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:sass:fix": "nx run @tee/web:sass-lint --fix",
     "type:check": "nx run-many -t type-check --verbose --parallel=false",
     "type:check:vue": "nx run @tee/web:type-check --verbose",
-    "ci": "npm run test && npm run lint && npm run type:check",
+    "ci": "nx run-many -t ci --verbose --parallel=false",
     "sass:watch": "nx run @tee/web:sass-watch"
   },
   "engines": {


### PR DESCRIPTION
Petit refacto de la command `npm run ci` afin de passer par les command nx au lieu de l'enchaînement de `npm run`.
Ca permet d'éviter de lancer plusieurs fois la même commande en dependence comme `generate:program`  