### PR TITLE
Fix: transmit establishment size in Opportunity

### DIFF
--- a/apps/web/src/service/api/opportunityApi.ts
+++ b/apps/web/src/service/api/opportunityApi.ts
@@ -1,6 +1,5 @@
 import { useUsedTrackStore } from '@/stores/usedTrack'
 import {
-  PublicodesKeys,
   QuestionnaireDataEnum,
   QuestionnaireRoute,
   TrackId,
@@ -67,7 +66,7 @@ export default class OpportunityApi extends RequestApi {
         companySiret: this._opportunityForm.siret.value,
         companyName: this.getFromUsedTrack(TrackId.Siret, 'denomination'),
         companySector: TrackStructure.getSector(),
-        companySize: (this.getFromUsedTrack(TrackId.StructureWorkforce, PublicodesKeys.Workforce) as unknown as number) ?? undefined, // get from usedTrack
+        companySize: TrackStructure.getSize() ?? undefined,
         message: this._opportunityForm.needs.value,
         questionnaireRoute: this.getFromUsedTrack(
           TrackId.QuestionnaireRoute,

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoContact.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoContact.ts
@@ -4,7 +4,7 @@ import { Result } from 'true-myth'
 import { ContactRepository } from '../../../domain/spi'
 import { BrevoCompanySize, BrevoPostContactPayload, ContactAttributes } from './types'
 import BrevoAPI from './brevoAPI'
-import { ContactDetails } from '@tee/common'
+import { ContactDetails, StructureSize } from '@tee/common'
 import Monitor from '../../../../common/domain/monitoring/monitor'
 
 const DEBUG_BREVO_LIST_ID = '4'
@@ -76,13 +76,26 @@ const convertDomainToBrevoContact = (contact: ContactDetails, optIn: true): Cont
   }
 }
 
-const convertCompanySize = (companySize: number): BrevoCompanySize => {
-  if (companySize < 20) {
-    return BrevoCompanySize.LESS_THAN_20
-  } else if (companySize <= 49) {
-    return BrevoCompanySize.FROM_20_TO_49
-  } else if (companySize <= 250) {
-    return BrevoCompanySize.FROM_50_TO_250
+const convertCompanySize = (companySize: StructureSize): BrevoCompanySize => {
+  switch (companySize) {
+    case StructureSize.EI:
+      return BrevoCompanySize.EI
+      break
+    case StructureSize.ETI_GE:
+      return BrevoCompanySize.MORE_THAN_250
+      break
+    case StructureSize.TPE:
+      return BrevoCompanySize.LESS_THAN_20
+      break
+    case StructureSize.PE:
+      return BrevoCompanySize.FROM_20_TO_49
+      break
+    case StructureSize.ME:
+      return BrevoCompanySize.FROM_50_TO_250
+      break
+    default:
+      Monitor.error('Company size not handled in brevoContact.')
+      return BrevoCompanySize.FROM_20_TO_49
+      break
   }
-  return BrevoCompanySize.MORE_THAN_250
 }

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoContact.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoContact.ts
@@ -80,22 +80,16 @@ const convertCompanySize = (companySize: StructureSize): BrevoCompanySize => {
   switch (companySize) {
     case StructureSize.EI:
       return BrevoCompanySize.EI
-      break
     case StructureSize.ETI_GE:
       return BrevoCompanySize.MORE_THAN_250
-      break
     case StructureSize.TPE:
       return BrevoCompanySize.LESS_THAN_20
-      break
     case StructureSize.PE:
       return BrevoCompanySize.FROM_20_TO_49
-      break
     case StructureSize.ME:
       return BrevoCompanySize.FROM_50_TO_250
-      break
     default:
       Monitor.error('Company size not handled in brevoContact.')
       return BrevoCompanySize.FROM_20_TO_49
-      break
   }
 }

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
@@ -73,7 +73,8 @@ export enum BrevoCompanySize {
   LESS_THAN_20 = 1,
   FROM_20_TO_49,
   FROM_50_TO_250,
-  MORE_THAN_250
+  MORE_THAN_250,
+  EI
 }
 
 export interface BrevoDealItem {

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/opportunityPayloadDTO.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/opportunityPayloadDTO.ts
@@ -43,10 +43,14 @@ export default class OpportunityPayloadDTO {
       SuppliedPhone: this.phoneNumber,
       SuppliedCompany: this.companyName,
       SIRET__c: this.companySiret,
-      Taille_de_lentreprise__c: this._companySize,
+      Taille_de_lentreprise__c: this.companySize,
       Description: this.description,
       Description_Complementaire__c: ''
     }
+  }
+
+  private get companySize(): string | number | undefined {
+    return this._companySize
   }
 
   private get companySiret(): string | undefined {

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/opportunityPayloadDTO.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/opportunityPayloadDTO.ts
@@ -1,6 +1,6 @@
 import { bpiOpportunityPayload } from './types'
 import { ProgramType } from '@tee/data'
-import { Opportunity } from '@tee/common'
+import { Opportunity, StructureSize } from '@tee/common'
 
 export default class OpportunityPayloadDTO {
   private readonly Subject = 'Demande d’échange' as const
@@ -9,7 +9,7 @@ export default class OpportunityPayloadDTO {
   private readonly point_de_contact__c = 'Site Plateforme Etat TEE' as const
   private readonly _companySiret: string | undefined
   private readonly _companyName: string | undefined | null
-  private readonly _companySize: number | undefined
+  private readonly _companySize: StructureSize | undefined
   private readonly _phoneNumber: string
   private readonly _lastName: string
   private readonly _firstName: string
@@ -43,14 +43,10 @@ export default class OpportunityPayloadDTO {
       SuppliedPhone: this.phoneNumber,
       SuppliedCompany: this.companyName,
       SIRET__c: this.companySiret,
-      Taille_de_lentreprise__c: this.companySize,
+      Taille_de_lentreprise__c: this._companySize,
       Description: this.description,
       Description_Complementaire__c: ''
     }
-  }
-
-  private get companySize(): string | number | undefined {
-    return this._companySize
   }
 
   private get companySiret(): string | undefined {

--- a/libs/common/src/opportunity/opportunityTypes.ts
+++ b/libs/common/src/opportunity/opportunityTypes.ts
@@ -1,4 +1,4 @@
-import { PublicodeObjective, QuestionnaireRoute } from '../questionnaire/types/types'
+import { PublicodeObjective, QuestionnaireRoute, StructureSize } from '../questionnaire/types/types'
 
 export type Opportunity = ContactDetails & OpportunityDetails
 
@@ -10,7 +10,7 @@ export interface ContactDetails {
   companySiret: string
   companyName?: string | null
   companySector?: string
-  companySize?: number
+  companySize?: StructureSize
 }
 
 export enum OpportunityType {

--- a/libs/data/tools/brevoExport/brevoExport.py
+++ b/libs/data/tools/brevoExport/brevoExport.py
@@ -9,7 +9,7 @@ import sib_api_v3_sdk
 from sib_api_v3_sdk.rest import ApiException
 
 # parameters
-BREVO_API_KEY_FILE_PATH = "../../../backend/.env"
+BREVO_API_KEY_FILE_PATH = "../../../../apps/backend/.env"
 REFRESH_CONTACTS = True  # True = use brevo API, False = use local file
 REFRESH_DEALS = True  # True = use brevo API, False = use local file
 EXPORT_TO_JSON = True

--- a/libs/data/tools/brevoExport/brevoExport.py
+++ b/libs/data/tools/brevoExport/brevoExport.py
@@ -245,6 +245,8 @@ def format_deal_stage(deal_stage):
         return "Transmise"
     elif deal_stage == 'c1d2ed92-8bc3-492d-a3ec-0284e214baa0':
         return "Perdue"
+    elif deal_stage == '659d15cff06be7.98275409':
+        return "Aide Proposée"
     else:
         print("unexpected deal stage", deal_stage)
         return "Inconnue"


### PR DESCRIPTION
- Mise à jour dans le front de la variable utilisée
- Mise à jour du format de données transmis
- Mise à jour de la conversion domain -> brevo
- Création d'un cas EI sur brevo
- Mise à jour testée et validée sur Brevo
- Mise à jour de la donnée transmise à BPI. ???? 

J'ai pas mal d'incertitudes sur la partie BPI. 
1/ je ne suis pas certain de ce qu'on doit leur transmettre. Un nombre ? Une string ? ... 
2/ je ne comprend pas bien ce qui a été fait sur le fichier OpportunityPayloadDTO.ts. Pourquoi des getters privés ont-ils été créés ? Qu'est ce qu'ils apportent ? 
3/ je transmet directement this._companySize qui est un enum dont la valeur finale est un string  | un undefined dans un type string | number | undefined . Cela vous semble t'il correct ? 