### PR TITLE
feat: modify programTypes (create a study program Type)

### DIFF
--- a/apps/web/src/components/program/detail/ProgramObjective.vue
+++ b/apps/web/src/components/program/detail/ProgramObjective.vue
@@ -49,7 +49,7 @@ const props = defineProps<Props>()
 
 const getProgramObjectiveTitle = () => {
   switch (props.program["nature de l'aide"]) {
-    case ProgramAidType.acc:
+    case ProgramAidType.study:
     case ProgramAidType.train:
     case ProgramAidType.loan:
     case ProgramAidType.tax:

--- a/apps/web/src/components/program/list/ProgramCard.vue
+++ b/apps/web/src/components/program/list/ProgramCard.vue
@@ -57,7 +57,7 @@ const getCostInfos = () => {
   let text: string | undefined = ''
 
   switch (program["nature de l'aide"]) {
-    case ProgramAidType.acc:
+    case ProgramAidType.study:
     case ProgramAidType.train:
       prefix = 'programCosts.costPrefix'
       text = program["coût de l'accompagnement"]

--- a/apps/web/src/components/program/list/ProgramCard.vue
+++ b/apps/web/src/components/program/list/ProgramCard.vue
@@ -58,6 +58,14 @@ const getCostInfos = () => {
 
   switch (program["nature de l'aide"]) {
     case ProgramAidType.study:
+      if (program["coût de l'accompagnement"]) {
+        text = program["coût de l'accompagnement"]
+        prefix = 'programCosts.costPrefix'
+      } else {
+        prefix = 'programCosts.aidPrefix'
+        text = program['montant du financement']
+      }
+      break
     case ProgramAidType.train:
       prefix = 'programCosts.costPrefix'
       text = program["coût de l'accompagnement"]

--- a/apps/web/src/components/program/list/filters/ProgramFilterByAidType.vue
+++ b/apps/web/src/components/program/list/filters/ProgramFilterByAidType.vue
@@ -14,9 +14,9 @@ import { DsfrCheckboxSetProps } from '@gouvminint/vue-dsfr'
 const programFilters: programFiltersType = useProgramStore().programFilters
 const programAidTypeOptions: DsfrCheckboxSetProps['options'] = [
   {
-    label: 'Accompagnement',
-    id: ProgramAidType.acc,
-    name: ProgramAidType.acc
+    label: 'Étude',
+    id: ProgramAidType.study,
+    name: ProgramAidType.study
   },
   {
     label: 'Financement',

--- a/etude-solaire-thermique.yaml
+++ b/etude-solaire-thermique.yaml
@@ -34,7 +34,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etude-faisabilite-dinstallation-solaire-thermique
-nature de l'aide: étude
+nature de l'aide: financement
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/backend-ddd/src/program/domain/sortPrograms.ts
+++ b/libs/backend-ddd/src/program/domain/sortPrograms.ts
@@ -65,7 +65,7 @@ const isFree = (program: ProgramType) => program["coût de l'accompagnement"]?.t
 
 const isMaybeFree = (program: ProgramType) => program["coût de l'accompagnement"]?.toLowerCase().includes('gratuit')
 
-const isCoachingOrTraining = (program: ProgramType) => hasType(ProgramAidType.acc, program) || hasType(ProgramAidType.train, program)
+const isCoachingOrTraining = (program: ProgramType) => hasType(ProgramAidType.study, program) || hasType(ProgramAidType.train, program)
 
 const objectifsNumber = (program: ProgramType) => {
   if (

--- a/libs/backend-ddd/tests/program/sortPrograms.test.ts
+++ b/libs/backend-ddd/tests/program/sortPrograms.test.ts
@@ -39,17 +39,17 @@ EXPECT that the programs respect a set of given rules
     },
     {
       name: 'single program',
-      programs: [makeProgram('1', ProgramAidType.acc)],
+      programs: [makeProgram('1', ProgramAidType.study)],
       expectedIdOrder: ['1']
     },
     {
       name: 'no reordering of coaching/training 1',
-      programs: [makeProgram('1', ProgramAidType.train), makeProgram('2', ProgramAidType.acc)],
+      programs: [makeProgram('1', ProgramAidType.train), makeProgram('2', ProgramAidType.study)],
       expectedIdOrder: ['1', '2']
     },
     {
       name: 'no reordering of coaching/training 2',
-      programs: [makeProgram('1', ProgramAidType.acc), makeProgram('2', ProgramAidType.train)],
+      programs: [makeProgram('1', ProgramAidType.study), makeProgram('2', ProgramAidType.train)],
       expectedIdOrder: ['1', '2']
     }
   ]
@@ -58,29 +58,29 @@ EXPECT that the programs respect a set of given rules
   const testCasesNoSpecificGoal: TestCase[] = [
     {
       name: 'free coaching first 1',
-      programs: [makeProgram('1', ProgramAidType.acc), makeProgram('2', ProgramAidType.acc, 'gratuit')],
+      programs: [makeProgram('1', ProgramAidType.study), makeProgram('2', ProgramAidType.study, 'gratuit')],
       expectedIdOrder: ['2', '1']
     },
     {
       name: 'free coaching first 2 (case insensitive)',
-      programs: [makeProgram('1', ProgramAidType.acc), makeProgram('2', ProgramAidType.acc, 'Gratuit')],
+      programs: [makeProgram('1', ProgramAidType.study), makeProgram('2', ProgramAidType.study, 'Gratuit')],
       expectedIdOrder: ['2', '1']
     },
     {
       name: 'possible free coaching second 1',
       programs: [
-        makeProgram('1', ProgramAidType.acc),
-        makeProgram('2', ProgramAidType.acc, 'Sur devis (gratuit en bretagne)'),
-        makeProgram('3', ProgramAidType.acc, 'gratuit')
+        makeProgram('1', ProgramAidType.study),
+        makeProgram('2', ProgramAidType.study, 'Sur devis (gratuit en bretagne)'),
+        makeProgram('3', ProgramAidType.study, 'gratuit')
       ],
       expectedIdOrder: ['3', '2', '1']
     },
     {
       name: 'possible free coaching second 2 (case insensitive)',
       programs: [
-        makeProgram('1', ProgramAidType.acc),
-        makeProgram('2', ProgramAidType.acc, 'Sur devis (Gratuit en bretagne)'),
-        makeProgram('3', ProgramAidType.acc, 'gratuit')
+        makeProgram('1', ProgramAidType.study),
+        makeProgram('2', ProgramAidType.study, 'Sur devis (Gratuit en bretagne)'),
+        makeProgram('3', ProgramAidType.study, 'gratuit')
       ],
       expectedIdOrder: ['3', '2', '1']
     },
@@ -91,9 +91,9 @@ EXPECT that the programs respect a set of given rules
         makeProgram('2', ProgramAidType.loan),
         makeProgram('3', ProgramAidType.fund),
         makeProgram('4', ProgramAidType.train),
-        makeProgram('5', ProgramAidType.acc),
-        makeProgram('6', ProgramAidType.acc, 'Sur devis (Gratuit en bretagne)'),
-        makeProgram('7', ProgramAidType.acc, 'gratuit')
+        makeProgram('5', ProgramAidType.study),
+        makeProgram('6', ProgramAidType.study, 'Sur devis (Gratuit en bretagne)'),
+        makeProgram('7', ProgramAidType.study, 'gratuit')
       ],
       expectedIdOrder: ['7', '6', '4', '5', '3', '2', '1']
     }
@@ -103,38 +103,38 @@ EXPECT that the programs respect a set of given rules
   const testCasesSpecificGoal: TestCase[] = [
     {
       name: 'free coaching last 1',
-      programs: [makeProgram('1', ProgramAidType.acc, 'gratuit'), makeProgram('2', ProgramAidType.acc)],
+      programs: [makeProgram('1', ProgramAidType.study, 'gratuit'), makeProgram('2', ProgramAidType.study)],
       expectedIdOrder: ['2', '1']
     },
     {
       name: 'free coaching last 2 (case insensitive)',
-      programs: [makeProgram('1', ProgramAidType.acc, 'Gratuit'), makeProgram('2', ProgramAidType.acc)],
+      programs: [makeProgram('1', ProgramAidType.study, 'Gratuit'), makeProgram('2', ProgramAidType.study)],
       expectedIdOrder: ['2', '1']
     },
     {
       name: 'possible free coaching second last 1',
       programs: [
-        makeProgram('1', ProgramAidType.acc, 'gratuit'),
-        makeProgram('2', ProgramAidType.acc, 'Sur devis (gratuit en bretagne)'),
-        makeProgram('3', ProgramAidType.acc)
+        makeProgram('1', ProgramAidType.study, 'gratuit'),
+        makeProgram('2', ProgramAidType.study, 'Sur devis (gratuit en bretagne)'),
+        makeProgram('3', ProgramAidType.study)
       ],
       expectedIdOrder: ['3', '2', '1']
     },
     {
       name: 'possible free coaching second last 2 (case insensitive)',
       programs: [
-        makeProgram('1', ProgramAidType.acc, 'gratuit'),
-        makeProgram('2', ProgramAidType.acc, 'Sur devis (Gratuit en bretagne)'),
-        makeProgram('3', ProgramAidType.acc)
+        makeProgram('1', ProgramAidType.study, 'gratuit'),
+        makeProgram('2', ProgramAidType.study, 'Sur devis (Gratuit en bretagne)'),
+        makeProgram('3', ProgramAidType.study)
       ],
       expectedIdOrder: ['3', '2', '1']
     },
     {
       name: 'correct ordering of types',
       programs: [
-        makeProgram('1', ProgramAidType.acc, 'gratuit'),
-        makeProgram('2', ProgramAidType.acc, 'Sur devis (Gratuit en bretagne)'),
-        makeProgram('3', ProgramAidType.acc),
+        makeProgram('1', ProgramAidType.study, 'gratuit'),
+        makeProgram('2', ProgramAidType.study, 'Sur devis (Gratuit en bretagne)'),
+        makeProgram('3', ProgramAidType.study),
         makeProgram('4', ProgramAidType.train),
         makeProgram('5', ProgramAidType.tax),
         makeProgram('6', ProgramAidType.loan),

--- a/libs/backend-ddd/tests/program/testing.ts
+++ b/libs/backend-ddd/tests/program/testing.ts
@@ -9,7 +9,7 @@ export const makeProgramHelper = ({
   id = '',
   rules = { [FILTERING_RULE_NAME]: { valeur: 'oui' } },
   cost = '1000 €',
-  nature = ProgramAidType.acc
+  nature = ProgramAidType.study
 }: {
   id?: string
   rules?: Rules

--- a/libs/data/programs/accelerateur-decarbonation.yaml
+++ b/libs/data/programs/accelerateur-decarbonation.yaml
@@ -11,7 +11,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: Bpifrance
 url: >-
   https://www.bpifrance.fr/nos-appels-a-projets-concours/candidatez-a-la-3e-promotion-de-laccelerateur-decarbonation 
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: 29 000 € HT
 durée de l'accompagnement: 39 jours de conseil et 8 jours de formation
 objectifs:

--- a/libs/data/programs/act-pas-a-pas.yaml
+++ b/libs/data/programs/act-pas-a-pas.yaml
@@ -34,7 +34,7 @@ début de validité: 13/11/2023
 fin de validité: 30/06/2026
 illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 15 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/adaptation-bzh.yaml
+++ b/libs/data/programs/adaptation-bzh.yaml
@@ -14,7 +14,7 @@ autres opérateurs:
   - Région Bretagne
 url: >-
   https://www.bretagne.cci.fr/developpement-durable/sadapter-au-changement-climatique/bretagne
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 8 heures de formation réparties sur quelques mois
 activable en autonomie: oui

--- a/libs/data/programs/aides-au-reemploi-des-emballages.yaml
+++ b/libs/data/programs/aides-au-reemploi-des-emballages.yaml
@@ -19,7 +19,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/aides-reemploi-emballages-contenants?cible=79
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude ou 60% de l'investissement
 objectifs:
   - description: >-

--- a/libs/data/programs/amo-chaufferie-biomasse.yaml
+++ b/libs/data/programs/amo-chaufferie-biomasse.yaml
@@ -25,7 +25,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/assistance-a-maitrise-douvrage-mise-place-dune-chaufferie-biomasse
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/audit-energetique-en-industrie.yaml
+++ b/libs/data/programs/audit-energetique-en-industrie.yaml
@@ -22,7 +22,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/audit-energetique-industrie
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/audits-clef-verte.yaml
+++ b/libs/data/programs/audits-clef-verte.yaml
@@ -45,7 +45,7 @@ url: >-
   https://www.cci.fr/offre/valorisez-les-demarches-environnementales-de-votre-entreprise
   et
   https://www.cci.fr/ressources/developpement-durable/contacts-developpement-durable
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: De 350 à 450 € HT selon votre activité
 durée de l'accompagnement: 1 jour dont 1/2 journée sur site
 activable en autonomie: oui

--- a/libs/data/programs/baisse-les-watts.yaml
+++ b/libs/data/programs/baisse-les-watts.yaml
@@ -21,7 +21,7 @@ autres opérateurs:
   - CMA
 url: >-
   https://www.baisseleswatts.fr/?mtm_campaign=missiontransitionecologique&mtm_source=missiontransitionecologique&mtm_medium=missiontransitionecologique&mtm_content=missiontransitionecologique
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 2 jours
 activable en autonomie: oui

--- a/libs/data/programs/booster-eco-energie-tertiaire.yaml
+++ b/libs/data/programs/booster-eco-energie-tertiaire.yaml
@@ -28,7 +28,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/booster-entreprises-reduire-facture-energetique-gagner-valeur-verte
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/climadiag-expert.yaml
+++ b/libs/data/programs/climadiag-expert.yaml
@@ -15,7 +15,7 @@ autres opérateurs:
   - ADEME
   - Agence de l'Eau
 url: https://www.grandest.cci.fr/produit/climadiag-expert
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 5 à 10 jours selon la taille de l'entreprise
 objectifs:

--- a/libs/data/programs/diag-decarbon-action.yaml
+++ b/libs/data/programs/diag-decarbon-action.yaml
@@ -8,7 +8,7 @@ opérateur de contact: Bpifrance
 autres opérateurs:
   - ADEME
 url: https://diag.bpifrance.fr/diag-decarbon-action
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: "4 000 € à 6 000 €\_HT après subvention de 60% à 40% selon la taille de l'entreprise"
 durée de l'accompagnement: 12 jours de prestation répartis sur 6 à 8 mois
 objectifs:

--- a/libs/data/programs/diag-eco-flux.yaml
+++ b/libs/data/programs/diag-eco-flux.yaml
@@ -11,7 +11,7 @@ opérateur de contact: Bpifrance
 autres opérateurs:
   - ADEME
 url: https://diag.bpifrance.fr/produit/diag-eco-flux
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: De 2 000 € HT à 3 000 € HT après subvention de 50%
 durée de l'accompagnement: 6 à 8 jours de prestation répartis sur 15 à 18 mois
 objectifs:

--- a/libs/data/programs/diag-ecoconception.yaml
+++ b/libs/data/programs/diag-ecoconception.yaml
@@ -8,7 +8,7 @@ opérateur de contact: Bpifrance
 autres opérateurs:
   - ADEME
 url: https://diag.bpifrance.fr/diag-eco-conception
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: >-
   5 400 € à 7 200 € HT après subvention de 70% à 60% selon la taille de
   l'entreprise

--- a/libs/data/programs/diag-perf-immo.yaml
+++ b/libs/data/programs/diag-perf-immo.yaml
@@ -19,7 +19,7 @@ autres opérateurs:
   - ADEME
 url: >-
   https://www.bpifrance.fr/catalogue-offres/transition-ecologique-et-energetique/diag-perfimmo
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: >-
   entre 3 000 € HT et 17 000 € HT (subventionné par l'ADEME à hauteur de 40% du
   montant HT, dans la limite de 6 800 € par site)

--- a/libs/data/programs/diagnostic-changement-climatique.yaml
+++ b/libs/data/programs/diagnostic-changement-climatique.yaml
@@ -11,7 +11,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: CCI
 autres opérateurs:
   - ADEME
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 3 jours
 objectifs:

--- a/libs/data/programs/diagnostic-dechets.yaml
+++ b/libs/data/programs/diagnostic-dechets.yaml
@@ -6,7 +6,7 @@ description: >-
   recyclage des déchets.
 illustration: images/TEE_eolienne.png
 opérateur de contact: CCI
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit selon les territoires ou reste à charge maximum de 1500 € HT
 durée de l'accompagnement: 3 jours dont 0,5 avec l'entreprise
 objectifs:

--- a/libs/data/programs/diagnostic-eco-conception-ile-de-france.yaml
+++ b/libs/data/programs/diagnostic-eco-conception-ile-de-france.yaml
@@ -22,7 +22,7 @@ autres opérateurs:
   - Bpifrance
 url: >-
   https://www.cci-paris-idf.fr/fr/entreprises/actualites/accompagnement-eco-conception-performance-environnementale
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: >-
   De 3 000 € à 6 000 € HT en fonction de la taille de l'entreprise, avec prise
   en charge possible jusqu'à 50%

--- a/libs/data/programs/diagnostic-rse.yaml
+++ b/libs/data/programs/diagnostic-rse.yaml
@@ -11,7 +11,7 @@ description: >-
 illustration: images/TEE_eolienne.png
 opérateur de contact: CCI
 url: https://www.cci.fr/offre/evaluez-votre-maturite-aux-enjeux-de-la-rse?&cp=75013
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Selon les territoires
 durée de l'accompagnement: 1 journée
 objectifs:

--- a/libs/data/programs/diagnostic-transition-ecologique.yaml
+++ b/libs/data/programs/diagnostic-transition-ecologique.yaml
@@ -9,7 +9,7 @@ description: >-
   de vos déchets, vos achats et vos mobilités.
 illustration: images/TEE_ampoule.png
 opérateur de contact: CCI
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit (sauf en PACA à partir de 650€ HT)
 durée de l'accompagnement: 1 jour dont 1/2 journée avec l'entreprise
 objectifs:

--- a/libs/data/programs/eco-defis-des-artisans-et-des-commercants.yaml
+++ b/libs/data/programs/eco-defis-des-artisans-et-des-commercants.yaml
@@ -7,7 +7,7 @@ description: >-
   emballages, responsabilité sociétale.
 illustration: images/TEE_energie_verte.png
 opérateur de contact: CCI ou CMA
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 2 jours de prestation répartis sur 12 mois
 objectifs:

--- a/libs/data/programs/ecoconception-bzh.yaml
+++ b/libs/data/programs/ecoconception-bzh.yaml
@@ -17,7 +17,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: CCI
 url: >-
   https://www.bretagne.cci.fr/developpement-durable/initier-une-demarche-deco-conception/bretagne
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Selon le nombre de participants
 durée de l'accompagnement: De 1 à 3 jours de prestation répartis sur 1 à 3 mois
 objectifs:

--- a/libs/data/programs/enviroveille.yaml
+++ b/libs/data/programs/enviroveille.yaml
@@ -9,7 +9,7 @@ description: >-
 illustration: images/TEE_eolienne.png
 opérateur de contact: CCI
 url: https://www.enviroveille.com/public/tester-gratuitement.html
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: De 150 à 800 € HT (sur abonnement)
 durée de l'accompagnement: 12 mois
 activable en autonomie: oui

--- a/libs/data/programs/etude-alimentation-durable.yaml
+++ b/libs/data/programs/etude-alimentation-durable.yaml
@@ -44,7 +44,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/subvention-etudes-dalimentation-durable
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-biodechets.yaml
+++ b/libs/data/programs/etude-biodechets.yaml
@@ -47,7 +47,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-gestion-biodechets-acteurs-economiques?cible=79
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-centres-de-tri.yaml
+++ b/libs/data/programs/etude-centres-de-tri.yaml
@@ -25,7 +25,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/realisation-detudes-creation-lextension-modernisation-centres-tri-dechets
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 50 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-chaufferie-biomasse.yaml
+++ b/libs/data/programs/etude-chaufferie-biomasse.yaml
@@ -30,7 +30,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-faisabilite-projets-chaufferie-biomasse
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-diagnostic-serres.yaml
+++ b/libs/data/programs/etude-diagnostic-serres.yaml
@@ -12,7 +12,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/diagnostic-energetique-identification-dactions-energetiques-prioritaires
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-economie-de-la-fonctionnalite.yaml
+++ b/libs/data/programs/etude-economie-de-la-fonctionnalite.yaml
@@ -24,7 +24,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/etude-associee-a-demarche-projet-deconomie-fonctionnalite
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-et-investissement-qualite-de-l’air.yaml
+++ b/libs/data/programs/etude-et-investissement-qualite-de-l’air.yaml
@@ -43,7 +43,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/actions-qualite-lair-territoires-contentieux
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 70% pour une étude et 55% pour un investissement
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-faisabilite-hydrogene.yaml
+++ b/libs/data/programs/etude-faisabilite-hydrogene.yaml
@@ -19,7 +19,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/sites/default/files/Opportunit%C3%A9%20et%20faisabilit%C3%A9%20d%C3%A9ploiement%20hydrog%C3%A8ne%20-%20Conditions%20d%27%C3%A9ligibilit%C3%A9%20et%20de%20financement%20-%202023.pdf
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 70% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-friches-polluees.yaml
+++ b/libs/data/programs/etude-friches-polluees.yaml
@@ -34,7 +34,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/etudes-prealables-a-reconversion-friches-a-risque-pollution-polluees?cible=79
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 70% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-gaspillage-alimentaire.yaml
+++ b/libs/data/programs/etude-gaspillage-alimentaire.yaml
@@ -23,7 +23,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-lutte-contre-gaspillage-alimentaire
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-geothermie-de-surface-et-d-aerothermie.yaml
+++ b/libs/data/programs/etude-geothermie-de-surface-et-d-aerothermie.yaml
@@ -32,7 +32,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etude-faisabilite-geothermie-surface-aerothermie
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-hydroelectricite.yaml
+++ b/libs/data/programs/etude-hydroelectricite.yaml
@@ -44,7 +44,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-installation-hydroelectrique?cible=79
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 70% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-methanisation.yaml
+++ b/libs/data/programs/etude-methanisation.yaml
@@ -45,7 +45,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/entreprises/aides-financieres/2024/etudes-prealables-a-construction-dune-installation-methanisation
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 70% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-performance-energetique-en-industrie.yaml
+++ b/libs/data/programs/etude-performance-energetique-en-industrie.yaml
@@ -49,7 +49,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-faisabilite-performance-energetique-decarbonation-dentreprises
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-performance-produits.yaml
+++ b/libs/data/programs/etude-performance-produits.yaml
@@ -10,7 +10,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-decoconception-produits-services
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-photovoltaique-ademe.yaml
+++ b/libs/data/programs/etude-photovoltaique-ademe.yaml
@@ -18,7 +18,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/etudes-faisabilite-lautoconsommation-electrique-photovoltaique
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: jusqu'à 70% du coût de l'étude
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-photovoltaique-cci.yaml
+++ b/libs/data/programs/etude-photovoltaique-cci.yaml
@@ -16,7 +16,7 @@ autres opérateurs:
   - ADEME
 url: >-
   https://www.saone-doubs.cci.fr/produit/etude-dopportunite-sur-votre-potentiel-photovoltaique
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 1/2 à 1 journée
 objectifs:

--- a/libs/data/programs/etude-projet-de-recherche.yaml
+++ b/libs/data/programs/etude-projet-de-recherche.yaml
@@ -30,7 +30,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/projets-recherche-developpement-innovation-rdi
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Selon projet
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-recuperation-de-chaleur-fatale.yaml
+++ b/libs/data/programs/etude-recuperation-de-chaleur-fatale.yaml
@@ -31,7 +31,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-faisabilite-linstallation-recuperation-chaleur-fatale
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-reemploi-reutilisation-reparation.yaml
+++ b/libs/data/programs/etude-reemploi-reutilisation-reparation.yaml
@@ -36,7 +36,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/soutien-etudes-diagnostics-reemploi-reutilisation-reparation-hors-emballages?cible=79
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-rehabilitation-solaires-thermiques-collectives.yaml
+++ b/libs/data/programs/etude-rehabilitation-solaires-thermiques-collectives.yaml
@@ -48,7 +48,7 @@ illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/audit-rehabilitation-dinstallations-solaires-thermiques-collectives
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: >-
   Selon la surface et l'ancienneté de l’installation solaire, dans un maximum de
   30 000€ HT

--- a/libs/data/programs/etude-reseaux-energie-renouvelable.yaml
+++ b/libs/data/programs/etude-reseaux-energie-renouvelable.yaml
@@ -14,7 +14,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2024/etudes-reseaux-chaleur-froid-alimentes-enr-enrr
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/etude-test-geothermie.yaml
+++ b/libs/data/programs/etude-test-geothermie.yaml
@@ -20,7 +20,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/test-reponse-thermique-terrain-geothermie
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude, dans un maximum de 100 000 €
 objectifs:
   - description: >-

--- a/libs/data/programs/extreme-defi-mobilite.yaml
+++ b/libs/data/programs/extreme-defi-mobilite.yaml
@@ -40,7 +40,7 @@ description longue: >
 illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: https://airtable.com/apprjFOnbLySO8spa/shraH0xKsFZnkZOKw
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: Jusqu'à 3 ans d'accompagnement
 activable en autonomie: oui

--- a/libs/data/programs/fonds-tourisme-durable.yaml
+++ b/libs/data/programs/fonds-tourisme-durable.yaml
@@ -19,7 +19,7 @@ description longue: >-
 
   • se former, se labelliser et communiquer sur l’engagement écologique.
 début de validité: 01/01/2023
-fin de validité: 31/12/2024
+fin de validité: 31/07/2024
 illustration: images/TEE_eolienne.png
 opérateur de contact: ADEME
 url: >-

--- a/libs/data/programs/fresque-de-la-mobilite.yaml
+++ b/libs/data/programs/fresque-de-la-mobilite.yaml
@@ -6,7 +6,7 @@ description: >-
   l'atelier qu'il vous faut pour bien démarrer le projet.
 illustration: images/TEE_ampoule.png
 opérateur de contact: CCI
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Sur devis
 durée de l'accompagnement: 1/2 journée
 objectifs:

--- a/libs/data/programs/gestion-des-biodechets.yaml
+++ b/libs/data/programs/gestion-des-biodechets.yaml
@@ -26,7 +26,7 @@ description longue: >-
 illustration: images/TEE_eolienne.png
 opérateur de contact: CCI
 url: https://hautsdefrance.cci.fr/solutions/accompagnement-gestion-biodechets/
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: De 750 à 3 500 € HT
 durée de l'accompagnement: De 1 à 5 jours selon la taille et le secteur d'activité de l'entreprise
 objectifs:

--- a/libs/data/programs/imprim-vert.yaml
+++ b/libs/data/programs/imprim-vert.yaml
@@ -18,7 +18,7 @@ description longue: >-
 illustration: images/TEE_ampoule.png
 opérateur de contact: CMA
 url: https://www.artisanat.fr/metiers/labels-qualifications/label-imprim-vert
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Sur devis, de 150 € à 450 € HT
 durée de l'accompagnement: 1 journée
 objectifs:

--- a/libs/data/programs/mission-conseil-rse.yaml
+++ b/libs/data/programs/mission-conseil-rse.yaml
@@ -10,7 +10,7 @@ début de validité: 01/01/2018
 illustration: images/TEE_eolienne.png
 opérateur de contact: Bpifrance
 url: https://www.bpifrance.fr/catalogue-offres/mission-de-conseil-rse
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: 13 000 € HT après subvention de 50%
 durée de l'accompagnement: 13 jours de prestation répartis sur 6 à 8 semaines
 objectifs:

--- a/libs/data/programs/mission-strategie-environnement.yaml
+++ b/libs/data/programs/mission-strategie-environnement.yaml
@@ -14,7 +14,7 @@ autres opérateurs:
   - InvestEU
 url: >-
   https://www.bpifrance.fr/catalogue-offres/transition-ecologique-et-energetique/mission-strategie-environnement
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: 5 000 € HT
 durée de l'accompagnement: 13 jours
 objectifs:

--- a/libs/data/programs/pacte-industrie.yaml
+++ b/libs/data/programs/pacte-industrie.yaml
@@ -36,7 +36,7 @@ illustration: images/TEE_ampoule.png
 opérateur de contact: ADEME
 url: >-
   https://agirpourlatransition.ademe.fr/entreprises/aides-financieres/2023/pacte-industrie-parcours-accompagnement-competences-transition-energetique-0
-nature de l'aide: financement
+nature de l'aide: étude
 montant du financement: Jusqu'à 80% du coût de l'étude selon la taille de l'entreprise
 objectifs:
   - description: >-

--- a/libs/data/programs/performa-environnement.yaml
+++ b/libs/data/programs/performa-environnement.yaml
@@ -11,7 +11,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: CMA
 url: >-
   https://www.artisanat.fr/nous-connaitre/vous-accompagner/performa-environnement
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 1 journée
 objectifs:

--- a/libs/data/programs/plan-de-mobilite.yaml
+++ b/libs/data/programs/plan-de-mobilite.yaml
@@ -46,7 +46,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: CCI
 url: >-
   https://www.entreprises.cci-paris-idf.fr/web/transition-ecologique/plan-de-mobilite-entreprise-ameliorez-l-accessibilite-de-votre-etablissement
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: de 3 000 € à 10 000 € en fonction de la taille de l'entreprise
 durée de l'accompagnement: 6 à 12 jours
 objectifs:

--- a/libs/data/programs/programme-breizh-fab.yaml
+++ b/libs/data/programs/programme-breizh-fab.yaml
@@ -15,7 +15,7 @@ autres opérateurs:
   - Région Bretagne
   - UIMM
 url: https://www.breizhfab.bzh/nos-solutions-daccompagnement/
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Etat des lieux gratuit, puis reste à charge de 325€ HT par jour engagé
 durée de l'accompagnement: 2 à 12 jours
 objectifs:

--- a/libs/data/programs/programme-ecod-o.yaml
+++ b/libs/data/programs/programme-ecod-o.yaml
@@ -16,7 +16,7 @@ autres opérateurs:
   - Véolia Eau
 url: >-
   https://www.bretagne.cci.fr/developper-son-entreprise/developpement-durable/le-programme-ecod-o
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: Selon l'entreprise
 objectifs:

--- a/libs/data/programs/programme-eve.yaml
+++ b/libs/data/programs/programme-eve.yaml
@@ -70,7 +70,7 @@ autres opérateurs:
   - CEE
   - Organisations professionnelles
 url: visite
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: Selon les projets
 objectifs:

--- a/libs/data/programs/programme-synergies-durables.yaml
+++ b/libs/data/programs/programme-synergies-durables.yaml
@@ -12,7 +12,7 @@ opérateur de contact: CCI
 url: >-
   https://www.cci.fr/offre/demarche-synergies-durables et
   https://www.cci.fr/ressources/developpement-durable/contacts-developpement-durable
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit sauf en Hauts-de-France et en Pays de la Loire (250 € HT)
 durée de l'accompagnement: Selon le projet
 objectifs:

--- a/libs/data/programs/renovation-petit-tertiaire-prive.yaml
+++ b/libs/data/programs/renovation-petit-tertiaire-prive.yaml
@@ -14,7 +14,7 @@ autres opérateurs:
   - France Rénov'
 url: >-
   https://www.ecologie.gouv.fr/sites/default/files/211130_guide_METRO_COPIL_VF2.pdf
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 2h
 objectifs:

--- a/libs/data/programs/repar-acteurs.yaml
+++ b/libs/data/programs/repar-acteurs.yaml
@@ -34,7 +34,7 @@ description longue: >-
 illustration: images/TEE_ampoule.png
 opérateur de contact: CMA
 url: https://www.artisanat.fr/nous-connaitre/vous-accompagner/reparacteurs
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 1/2 journée
 activable en autonomie: oui

--- a/libs/data/programs/tourisme-durable-paca.yaml
+++ b/libs/data/programs/tourisme-durable-paca.yaml
@@ -12,7 +12,7 @@ description: >-
 illustration: images/TEE_energie_verte.png
 opérateur de contact: CCI
 url: https://www.cciamp.com/produit/tourisme-durable-atelier-RSE
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: à partir de 450 € HT par participant (ou financement OPCO)
 durée de l'accompagnement: 1 journée
 objectifs:

--- a/libs/data/programs/tpe-gagnantes-sur-tous-les-couts.yaml
+++ b/libs/data/programs/tpe-gagnantes-sur-tous-les-couts.yaml
@@ -9,7 +9,7 @@ illustration: images/TEE_energie_verte.png
 opérateur de contact: CMA
 url: >-
   https://www.artisanat.fr/magazine/series-podcasts/tpe-pme-gagnantes-sur-tous-couts
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 5 jours de prestation répartis sur 12 mois
 objectifs:

--- a/libs/data/programs/trophees-crisalide-eco-activites.yaml
+++ b/libs/data/programs/trophees-crisalide-eco-activites.yaml
@@ -16,7 +16,7 @@ description longue: |-
 illustration: images/TEE_eolienne.png
 opérateur de contact: CCI
 url: https://www.crisalide-ecoactivites.fr/
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: Un parcours sur 3 mois
 activable en autonomie: oui

--- a/libs/data/programs/visite-energie-cci.yaml
+++ b/libs/data/programs/visite-energie-cci.yaml
@@ -13,7 +13,7 @@ url: >-
   https://www.cci.fr/offre/parcours-energie-pour-reduire-votre-facture-energie
   et
   https://www.cci.fr/ressources/developpement-durable/contacts-developpement-durable
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit (sauf en Bretagne, Ile-de-France et Normandie à partir de 1 500€ HT)
 durée de l'accompagnement: 2 à 5 jours
 objectifs:

--- a/libs/data/programs/visite-energie-cma.yaml
+++ b/libs/data/programs/visite-energie-cma.yaml
@@ -7,7 +7,7 @@ description: >-
   en place pour réaliser des économies d'énergie.
 illustration: images/TEE_eolienne.png
 opérateur de contact: CMA
-nature de l'aide: accompagnement
+nature de l'aide: étude
 coût de l'accompagnement: Gratuit
 durée de l'accompagnement: 1 journée
 objectifs:

--- a/libs/data/schemas/program-data-schema.json
+++ b/libs/data/schemas/program-data-schema.json
@@ -149,27 +149,27 @@
       "uniqueItems": true
     },
     "type de l'aide": {
-      "description": "Précise s'il s'agit d'une aide financière, d'un accompagnement, ou d'un prêt, d'une formation ou d'un avantage fiscal. Un accompagnement se définit comme la réalisation d'une prestation intellectuelle, par un intervenant choisi par l'opérateur.",
-      "enum": ["accompagnement", "formation", "financement", "avantage fiscal", "prêt"]
+      "description": "Précise s'il s'agit d'une aide financière, d'une étude, ou d'un prêt, d'une formation ou d'un avantage fiscal.",
+      "enum": ["étude", "formation", "financement", "avantage fiscal", "prêt"]
     },
     "activable en autonomie": {
       "description": "Précise s'il s'agit d'un dispositif en autonomie ou s'il y aura des interactions avec l'opérateur.",
       "type": "string"
     },
     "coût de l'accompagnement": {
-      "description": "Uniquement si l'aide est de type \"accompagnement\". Le coût reste à charge correspond au montant que devra payer l'entreprise pour bénéficier d'un accompagnement, après déduction de la subvention.\n\n Formulation :\n- 10 mots max\n- selon le format \"x € HT après subvention de x%\"\n- écriture des chiffres en unités numériques\n- ne pas utiliser d'abréviations (ex : utiliser jour et non l'abréviation \"j.\")",
+      "description": "Le coût reste à charge correspond au montant que devra payer l'entreprise pour bénéficier d'un accompagnement, après déduction de la subvention.\n\n Formulation :\n- 10 mots max\n- selon le format \"x € HT après subvention de x%\"\n- écriture des chiffres en unités numériques\n- ne pas utiliser d'abréviations (ex : utiliser jour et non l'abréviation \"j.\")",
       "examples": ["4 000 € HT après subvention de 60%"],
       "type": "string"
     },
     "durée de l'accompagnement": {
       "title": "Durée de la prestation et son étalement dans le temps",
-      "description": "Ce champ est utile et requis uniquement si l'aide est de type \"accompagnement\".\n\nFormulation :\n- 10 mots max.\n- selon le format \" n jours de prestation répartis sur x mois\"\n- écriture des chiffres en unités numériques\n- ne pas utiliser d'abréviations (ex : utiliser jour et non l'abréviation \"j.\")\n- utiliser \"journée\" au singulier (et non jour)",
+      "description": "Formulation :\n- 10 mots max.\n- selon le format \" n jours de prestation répartis sur x mois\"\n- écriture des chiffres en unités numériques\n- ne pas utiliser d'abréviations (ex : utiliser jour et non l'abréviation \"j.\")\n- utiliser \"journée\" au singulier (et non jour)",
       "examples": ["12 jours de prestation répartis sur 6 à 8 mois"],
       "type": "string"
     },
     "montant du financement": {
       "title": "Montant du financement",
-      "description": "Uniquement si l'aide est de type \"financement\". Le montant de l'aide correspond au montant de financement ou de prêt auquel l'entreprise peut prétendre pour financer son projet / son étude.\n\nFormulation :\n- 10 mots max.\nLes objectifs aparaissent sous la dénomination de \"au programme :\" pour les accompagnements. Ils ont pour objectif de détailler les grandes étapes de l'accompagnement.\n- Les objectifs apparaissent sous la dénomination de \"Les étapes de votre demande d’aide :\" pour les financements. Ils ont pour objectifs de détailler comment se passe la démarche pour obtenir le financement en question.",
+      "description": "Le montant de l'aide correspond au montant de financement ou de prêt auquel l'entreprise peut prétendre pour financer son projet / son étude.\n\nFormulation :\n- 10 mots max.\nLes objectifs aparaissent sous la dénomination de \"au programme :\" pour les accompagnements. Ils ont pour objectif de détailler les grandes étapes de l'accompagnement.\n- Les objectifs apparaissent sous la dénomination de \"Les étapes de votre demande d’aide :\" pour les financements. Ils ont pour objectifs de détailler comment se passe la démarche pour obtenir le financement en question.",
       "examples": ["jusqu'à 70% du coût de l'étude", "selon projet", "de 5 000 € HT à 200 000 € HT"],
       "type": "string"
     },

--- a/libs/data/schemas/program-with-publicodes-schema.json
+++ b/libs/data/schemas/program-with-publicodes-schema.json
@@ -81,8 +81,8 @@
       "uniqueItems": true
     },
     "nature de l'aide": {
-      "description": "Précise s'il s'agit d'une aide financière, d'un accompagnement, ou d'un prêt. Un accompagnement se définit comme la réalisation d'une prestation intellectuelle, par un intervenant choisi par l'opérateur.",
-      "enum": ["accompagnement", "formation", "financement", "avantage fiscal", "prêt"]
+      "description": "Précise s'il s'agit d'une aide financière, d'une étude, ou d'un prêt.",
+      "enum": ["étude", "formation", "financement", "avantage fiscal", "prêt"]
     },
     "activable en autonomie": {
       "description": "Précise s'il s'agit d'un dispositif en autonomie ou s'il y aura des interactions avec l'opérateur.",
@@ -185,12 +185,7 @@
   "oneOf": [
     {
       "properties": {
-        "nature de l'aide": {
-          "oneOf": [
-          {"const": "accompagnement" },
-          {"const": "formation" }
-          ]
-        }
+        "nature de l'aide": { "const": "formation" }
       },
       "required": ["coût de l'accompagnement", "durée de l'accompagnement"]
     },
@@ -211,6 +206,19 @@
         "nature de l'aide": { "const": "prêt" }
       },
       "required": ["durée du prêt", "montant du prêt"]
+    },
+    {
+      "properties": {
+        "nature de l'aide": { "const": "étude" }
+      },
+      "anyOf": [
+        {
+          "required": ["coût de l'accompagnement", "durée de l'accompagnement"]
+        },
+        {
+          "required": ["montant du financement"]
+        }
+      ]
     }
   ],
   "required": [

--- a/libs/data/src/program/program.ts
+++ b/libs/data/src/program/program.ts
@@ -4,7 +4,7 @@ export class Program {
   public static getPrefixedProgramName(program: ProgramType) {
     let prefix = ''
     switch (program["nature de l'aide"]) {
-      case ProgramAidType.acc:
+      case ProgramAidType.study:
         prefix = `l'`
         break
       case ProgramAidType.train:

--- a/libs/data/src/program/programYamlGenerator.ts
+++ b/libs/data/src/program/programYamlGenerator.ts
@@ -57,7 +57,7 @@ export class ProgramYamlGenerator {
       program['Autres opérateurs'].map((operator) => operator.Nom)
     )
     addField('url', program['URL externe'])
-    addField("nature de l'aide", program["Nature de l'aide"].toLowerCase())
+    this._setProgramType(yamlContent, program)
     this._setFinancialData(yamlContent, program)
     if (program['Dispositif activable en autonomie']) {
       addField('activable en autonomie', 'oui')
@@ -68,6 +68,13 @@ export class ProgramYamlGenerator {
 
     const yamlString = yaml.dump(yamlContent)
     fs.writeFileSync('programs/' + program['Id fiche dispositif'] + '.yaml', yamlString, 'utf8')
+  }
+  private _setProgramType(fileContent: { [key: string]: unknown }, program: DataProgram) {
+    let helpType = program["Nature de l'aide"].toLowerCase()
+    if (helpType === 'financement-étude') {
+      helpType = 'étude'
+    }
+    fileContent["nature de l'aide"] = helpType
   }
 
   private _setIllustration(programId: string): string {
@@ -86,11 +93,11 @@ export class ProgramYamlGenerator {
   }
 
   private _setFinancialData(fileContent: { [key: string]: unknown }, program: DataProgram) {
-    if (program["Nature de l'aide"] == DataProgramType.Financing) {
+    if (program["Nature de l'aide"] == DataProgramType.Financing || program["Nature de l'aide"] == DataProgramType.FinancingStudy) {
       fileContent['montant du financement'] = program["Montant de l'aide"]
       return
     }
-    if (program["Nature de l'aide"] == DataProgramType.Accompagnement || program["Nature de l'aide"] == DataProgramType.Training) {
+    if (program["Nature de l'aide"] == DataProgramType.Study || program["Nature de l'aide"] == DataProgramType.Training) {
       fileContent["coût de l'accompagnement"] = program["Montant de l'aide"]
       fileContent["durée de l'accompagnement"] = program["Durée de l'aide"]
       return

--- a/libs/data/src/program/programYamlGenerator.ts
+++ b/libs/data/src/program/programYamlGenerator.ts
@@ -96,19 +96,19 @@ export class ProgramYamlGenerator {
     switch (program["Nature de l'aide"]) {
       case DataProgramType.Financing:
       case DataProgramType.FinancingStudy:
-        fileContent['montant du financement'] = program["Montant de l'aide"]
+        fileContent['montant du financement'] = program["Montant de l'aide ou coût"]
         return
       case DataProgramType.Study:
       case DataProgramType.Training:
-        fileContent["coût de l'accompagnement"] = program["Montant de l'aide"]
+        fileContent["coût de l'accompagnement"] = program["Montant de l'aide ou coût"]
         fileContent["durée de l'accompagnement"] = program["Durée de l'aide"]
         return
       case DataProgramType.Loan:
-        fileContent['montant du prêt'] = program["Montant de l'aide"]
+        fileContent['montant du prêt'] = program["Montant de l'aide ou coût"]
         fileContent['durée du prêt'] = program["Durée de l'aide"]
         return
       case DataProgramType.TaxAdvantage:
-        fileContent["montant de l'avantage fiscal"] = program["Montant de l'aide"]
+        fileContent["montant de l'avantage fiscal"] = program["Montant de l'aide ou coût"]
         return
       default:
         console.log("type d'aide non traitée dans les données financières")

--- a/libs/data/src/program/programYamlGenerator.ts
+++ b/libs/data/src/program/programYamlGenerator.ts
@@ -93,26 +93,27 @@ export class ProgramYamlGenerator {
   }
 
   private _setFinancialData(fileContent: { [key: string]: unknown }, program: DataProgram) {
-    if (program["Nature de l'aide"] == DataProgramType.Financing || program["Nature de l'aide"] == DataProgramType.FinancingStudy) {
-      fileContent['montant du financement'] = program["Montant de l'aide"]
-      return
+    switch (program["Nature de l'aide"]) {
+      case DataProgramType.Financing:
+      case DataProgramType.FinancingStudy:
+        fileContent['montant du financement'] = program["Montant de l'aide"]
+        return
+      case DataProgramType.Study:
+      case DataProgramType.Training:
+        fileContent["coût de l'accompagnement"] = program["Montant de l'aide"]
+        fileContent["durée de l'accompagnement"] = program["Durée de l'aide"]
+        return
+      case DataProgramType.Loan:
+        fileContent['montant du prêt'] = program["Montant de l'aide"]
+        fileContent['durée du prêt'] = program["Durée de l'aide"]
+        return
+      case DataProgramType.TaxAdvantage:
+        fileContent["montant de l'avantage fiscal"] = program["Montant de l'aide"]
+        return
+      default:
+        console.log("type d'aide non traitée dans les données financières")
+        return
     }
-    if (program["Nature de l'aide"] == DataProgramType.Study || program["Nature de l'aide"] == DataProgramType.Training) {
-      fileContent["coût de l'accompagnement"] = program["Montant de l'aide"]
-      fileContent["durée de l'accompagnement"] = program["Durée de l'aide"]
-      return
-    }
-    if (program["Nature de l'aide"] == DataProgramType.Loan) {
-      fileContent['montant du prêt'] = program["Montant de l'aide"]
-      fileContent['durée du prêt'] = program["Durée de l'aide"]
-      return
-    }
-    if (program["Nature de l'aide"] == DataProgramType.TaxAdvantage) {
-      fileContent["montant de l'avantage fiscal"] = program["Montant de l'aide"]
-      return
-    }
-    console.log("type d'aide non traitée dans les données financières")
-    return
   }
 
   private _parseStep(step: string): YamlObjective {

--- a/libs/data/src/program/types/domain.ts
+++ b/libs/data/src/program/types/domain.ts
@@ -99,9 +99,10 @@ export interface GeographicAreas {
 }
 
 export enum DataProgramType {
-  Accompagnement = 'Accompagnement',
+  Study = 'étude',
   TaxAdvantage = 'Avantage fiscal',
   Financing = 'Financement',
+  FinancingStudy = 'Financement-étude',
   Loan = 'Prêt',
   Training = 'Formation',
   ActionTraining = 'Formation-Action',

--- a/libs/data/src/program/types/domain.ts
+++ b/libs/data/src/program/types/domain.ts
@@ -11,7 +11,7 @@ export interface DataProgram {
   'Dispositif activable en autonomie': boolean
   'Parcours "Je ne sais pas par où commencer"': boolean
   'URL externe': string
-  "Montant de l'aide": string
+  "Montant de l'aide ou coût": string
   "Durée de l'aide": string
   DISPOSITIF_DATE_DEBUT: string
   DISPOSITIF_DATE_FIN: string

--- a/libs/data/src/program/types/shared.ts
+++ b/libs/data/src/program/types/shared.ts
@@ -1,5 +1,5 @@
 export enum ProgramAidType {
-  acc = 'accompagnement',
+  study = 'étude',
   train = 'formation',
   fund = 'financement',
   loan = 'prêt',


### PR DESCRIPTION
Features :
- Supprime le type Accompagnement et le transforme en "étude"
- Modifie certians financements en études

Détails techs : 
- sur baserow renommage du type Accompagnement en étude
- sur baserow, création d'un nouveau type "financement-étude" (obligation de distinguer les deux types pour avoir deux affichages distincts des infos financières )  
- dans le script de création des yamls, création des champs financiers correspond et merge des deux types "étude" et "financement-étude" en un seul type "étude".
- affichge du type "étude" sur le front en remplacement du type "accompagnement". 

Exemple d'accompagnement devenu étude : audits-clef-verte
Exemple de financement devenur étude : etude-centres-de-tri

En principe, les deux fiches doivent être exactement identiques exceptées la mention étude vs l'ancien type. 
C'était non trivial pour les données de financements. 

Sinon il pourrait rester des endroits où il faut ajouter un article avant le mot étude ou d'autres détails d'affichage conditionnel. 
J'ai recherché toutes les occurences de "ProgramAidType" et j'ai vu qu'il était utilisé sur ProgramObjective et sur ProgramCard.
J'ai l'impression qu'il n'y a rien à ajouter sur ces fichiers mais je peux me tromper. 


close #224

