### PR TITLE
Fix : Plus de marges blanches sur les cartes projets et programs

### DIFF
--- a/apps/web/src/assets/scss/card.scss
+++ b/apps/web/src/assets/scss/card.scss
@@ -23,7 +23,7 @@
       }
     }
 
-    .fr-card__img img {
+    .fr-card__img--contain img {
       object-fit: contain;
     }
   }

--- a/apps/web/src/components/objective/ThemeCard.vue
+++ b/apps/web/src/components/objective/ThemeCard.vue
@@ -38,7 +38,7 @@
       class="fr-hidden-xs fr-card__header"
       :class="`fr-card__header--${option.color}`"
     >
-      <div class="fr-card__img">
+      <div class="fr-card__img fr-card__img--contain">
         <img
           class="fr-responsive-img"
           height="200px"


### PR DESCRIPTION
La règle scss est maintenant appliquée uniquement si on rajoute la classe fr-card__img--contain