### PR TITLE
feat: add delayed scrolling behavior to hash links

### DIFF
--- a/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
+++ b/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
@@ -11,7 +11,6 @@ import { RouteName } from '@/types/routeType'
 import { type RouteLocationAsRelativeGeneric } from 'vue-router'
 interface Props {
   links?: DsfrBreadcrumbProps['links']
-  resultHash?: string
 }
 const props = defineProps<Props>()
 const navigationStore = useNavigationStore()
@@ -41,7 +40,6 @@ const getBaseRouteName = () => {
 
 const routeToBaseList: RouteLocationAsRelativeGeneric = {
   name: getBaseRouteName(),
-  hash: props.resultHash,
   query: isCatalogDetail ? undefined : navigationStore.query
 }
 

--- a/apps/web/src/components/program/detail/ProgramHeader.vue
+++ b/apps/web/src/components/program/detail/ProgramHeader.vue
@@ -1,13 +1,9 @@
 <template>
-  <TeeDsfrBreadcrumb
-    :links="links"
-    :result-hash="`#${programId}`"
-  />
+  <TeeDsfrBreadcrumb :links="links" />
   <TeeEligibilityCriteriaBar
     v-if="!isCatalogDetail"
     :bg-color="Color.greenLightnessed"
     :bg-bar-color="Color.greenLighted"
-    :previous-route="getRouteToPreviousPage()"
     message="Cette aide correspond à vos critères d’éligibilité"
     message-icon="fr-icon-checkbox-circle-fill"
   />
@@ -80,16 +76,8 @@ const links = computed<DsfrBreadcrumbProps['links']>(() => {
   return [...links, { text: props.program?.titre || '' }]
 })
 
-const getRouteToPreviousPage = () => {
-  if (navigationStore.isByRouteName(RouteName.ProgramFromProjectDetail)) {
-    return routeToProject
-  }
-
-  return routeToResults
-}
-
-const goToPrograms = async () => {
-  await router.push(getRouteToPreviousPage())
+const goToPrograms = () => {
+  router.back()
 }
 onBeforeMount(() => {
   project.value = projectStore.currentProject

--- a/apps/web/src/components/program/eligibilityCriteria/TeeEligibilityCriteriaBar.vue
+++ b/apps/web/src/components/program/eligibilityCriteria/TeeEligibilityCriteriaBar.vue
@@ -7,13 +7,14 @@
     <div class="fr-container fr-grid-row fr-grid-row--center fr-grid-row--middle fr-py-md-1w">
       <div class="fr-col-md-2 fr-col-lg-2 fr-col-xl-2 fr-col-hidden fr-col-unhidden-md">
         <div class="fr-col-12">
-          <TeeButtonLink
-            :to="previousRoute"
+          <TeeDsfrButton
+            :label="`Retour`"
             icon="fr-icon-arrow-left-line"
+            class="fr-btn fr-btn--tertiary-no-outline fr-btn-bg"
             size="lg"
+            @click="router.back()"
           >
-            Retour
-          </TeeButtonLink>
+          </TeeDsfrButton>
         </div>
       </div>
       <div class="fr-px-md-2v fr-my-auto fr-col-hidden fr-col-unhidden-md fr-col-md-10 fr-col-lg-10 fr-col-xl-10 fr-px-0 fr-text-left">
@@ -44,12 +45,10 @@ import { useNavigationStore } from '@/stores/navigation'
 import { Color, RouteName } from '@/types'
 import StickyWithOffset from '@/utils/stickyWithOffset'
 import TrackStructure from '@/utils/track/trackStructure'
-import type { RouteLocationRaw } from 'vue-router'
 
 interface Props {
   bgColor?: Color
   bgBarColor?: Color
-  previousRoute: RouteLocationRaw
   message?: string
   messageIcon?: string
 }
@@ -58,6 +57,7 @@ const props = defineProps<Props>()
 const eligibilityCriteria = ref<HTMLElement>()
 const stickyWithOffset = ref<StickyWithOffset | null>(null)
 const criteria = TrackStructure.getEligibilityCriteria()
+const router = useRouter()
 
 function isProgramDetailPage() {
   return useNavigationStore().isByRouteName([RouteName.CatalogProgramDetail, RouteName.QuestionnaireResultDetail])

--- a/apps/web/src/components/project/details/ProjectHeader.vue
+++ b/apps/web/src/components/project/details/ProjectHeader.vue
@@ -1,12 +1,8 @@
 <template>
-  <TeeDsfrBreadcrumb
-    :links="links"
-    :result-hash="`#${project.slug}`"
-  />
+  <TeeDsfrBreadcrumb :links="links" />
   <TeeEligibilityCriteriaBar
     :bg-color="Color.blueLightnessed"
     :bg-bar-color="Color.blueLighted"
-    :previous-route="routeToProjects"
   />
   <div class="fr-mb-4v background-project-title">
     <img
@@ -29,8 +25,6 @@
 </template>
 <script setup lang="ts">
 import { Color, Project } from '@/types'
-import { RouteName } from '@/types/routeType'
-import { useNavigationStore } from '@/stores/navigation'
 import type { DsfrBreadcrumbProps } from '@gouvminint/vue-dsfr'
 
 interface Props {
@@ -38,13 +32,7 @@ interface Props {
   themeColor?: Color
 }
 const props = defineProps<Props>()
-const navigationStore = useNavigationStore()
 
-const routeToProjects = {
-  name: RouteName.QuestionnaireResult,
-  hash: '#' + props.project.slug,
-  query: navigationStore.query
-}
 const links = ref<DsfrBreadcrumbProps['links']>([{ text: props.project.title }])
 </script>
 

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -8,14 +8,7 @@ export const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
   scrollBehavior(to: RouteLocationNormalized, from: RouteLocationNormalizedLoaded, savedPosition) {
     if (savedPosition) {
-      return savedPosition
-    }
-    if (to.hash) {
-      return new Promise((resolve) => {
-        setTimeout(() => {
-          resolve({ el: to.hash, behavior: 'instant' })
-        }, 0)
-      })
+      return Promise.resolve(savedPosition)
     }
     return { top: 0 }
   },

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -3,7 +3,6 @@
 
 import { createRouter, createWebHistory, type RouteLocationNormalized, type RouteLocationNormalizedLoaded } from 'vue-router'
 import { routes } from '@/router/routes'
-import { RouteName } from '@/types'
 
 export const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
@@ -13,12 +12,9 @@ export const router = createRouter({
     }
     if (to.hash) {
       return new Promise((resolve) => {
-        setTimeout(
-          () => {
-            resolve({ el: to.hash, behavior: 'instant' })
-          },
-          from.name === RouteName.ProgramFromProjectDetail ? 500 : 0
-        )
+        setTimeout(() => {
+          resolve({ el: to.hash, behavior: 'instant' })
+        }, 0)
       })
     }
     return { top: 0 }

--- a/apps/web/src/router/index.ts
+++ b/apps/web/src/router/index.ts
@@ -3,6 +3,7 @@
 
 import { createRouter, createWebHistory, type RouteLocationNormalized, type RouteLocationNormalizedLoaded } from 'vue-router'
 import { routes } from '@/router/routes'
+import { RouteName } from '@/types'
 
 export const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
@@ -11,7 +12,14 @@ export const router = createRouter({
       return savedPosition
     }
     if (to.hash) {
-      return { el: to.hash }
+      return new Promise((resolve) => {
+        setTimeout(
+          () => {
+            resolve({ el: to.hash, behavior: 'instant' })
+          },
+          from.name === RouteName.ProgramFromProjectDetail ? 500 : 0
+        )
+      })
     }
     return { top: 0 }
   },


### PR DESCRIPTION
Ajout d'un timeOut à la création du router pour attendre la fin d'éventuelles transitions sur les pages et le chargement des éléments.
Ainsi on s'assure que l'élément ciblé par le tag passé dans l'url est bien présent sur la page au moment d'activer l'action de scroll.