### PR TITLE
Feat: update opportunity status on transmission

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -17,6 +17,7 @@ BREVO_SANDBOX=true
 # https://developers.brevo.com/reference/get_crm-pipeline-details-all
 # Example value : test pipeline
 BREVO_DEAL_PIPELINE=65ce1a5e59d96ff2630f06c8
+# warning there is a hard copy of this value in the codebase
 
 # Where should the brevo contacts be created (example value : test list)
 BREVO_LIST_IDS=4

--- a/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
+++ b/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
@@ -9,7 +9,7 @@ import { Operators, ProgramType, Project } from '@tee/data'
 import { ContactDetails, Opportunity, OpportunityType, SiretValidator } from '@tee/common'
 import EstablishmentService from '../../establishment/application/establishmentService'
 import Monitor from '../../common/domain/monitoring/monitor'
-import { projects } from '@tee/data/static'
+import { ProjectService } from '../../project/application/projectService'
 
 export default class OpportunityFeatures {
   private readonly _contactRepository: ContactRepository
@@ -76,7 +76,7 @@ export default class OpportunityFeatures {
   }
 
   private async _createProjectOpportunity(opportunity: Opportunity, contactId: ContactId): Promise<Result<OpportunityId, Error>> {
-    const project = projects.find((project) => project.id === +opportunity.id)
+    const project = new ProjectService().getById(+opportunity.id)
     if (!project) {
       return Result.err(new Error('Project with id ' + opportunity.id + 'not found'))
     }

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -105,9 +105,14 @@ const convertDomainToBrevoDeal = (domainAttributes: OpportunityWithOperatorConta
 
 const convertDomainToBrevoDealUpdate = (domainUpdateAttributes: OpportunityUpdateAttributes): DealUpdateAttributes => {
   if (domainUpdateAttributes.sentToOpportunityHub) {
+    let deal_stage = BrevoStatus.Transmitted
+    if (Config.BREVO_DEAL_PIPELINE == '65ce1a5e59d96ff2630f06c8') {
+      // test value, already public in app/backend/.env.exemple
+      deal_stage = BrevoStatus.TestTransmitted
+    }
     return {
       envoy: domainUpdateAttributes.sentToOpportunityHub,
-      deal_stage: BrevoStatus.Transmitted
+      deal_stage: deal_stage
     }
   } else {
     return {

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -8,7 +8,8 @@ import {
   DealUpdateAttributes,
   BrevoPostDealPayload,
   BrevoDealResponse,
-  BrevoDealItem
+  BrevoDealItem,
+  BrevoStatus
 } from './types'
 import Config from '../../../../config'
 import { QuestionnaireRoute } from '@tee/common'
@@ -103,8 +104,15 @@ const convertDomainToBrevoDeal = (domainAttributes: OpportunityWithOperatorConta
 }
 
 const convertDomainToBrevoDealUpdate = (domainUpdateAttributes: OpportunityUpdateAttributes): DealUpdateAttributes => {
-  return {
-    envoy: domainUpdateAttributes.sentToOpportunityHub
+  if (domainUpdateAttributes.sentToOpportunityHub) {
+    return {
+      envoy: domainUpdateAttributes.sentToOpportunityHub,
+      deal_stage: BrevoStatus.Transmitted
+    }
+  } else {
+    return {
+      envoy: domainUpdateAttributes.sentToOpportunityHub
+    }
   }
 }
 

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -9,7 +9,7 @@ import {
   BrevoPostDealPayload,
   BrevoDealResponse,
   BrevoDealItem,
-  BrevoStatus
+  BrevoDealStatus
 } from './types'
 import Config from '../../../../config'
 import { QuestionnaireRoute } from '@tee/common'
@@ -105,14 +105,9 @@ const convertDomainToBrevoDeal = (domainAttributes: OpportunityWithOperatorConta
 
 const convertDomainToBrevoDealUpdate = (domainUpdateAttributes: OpportunityUpdateAttributes): DealUpdateAttributes => {
   if (domainUpdateAttributes.sentToOpportunityHub) {
-    let deal_stage = BrevoStatus.Transmitted
-    if (Config.BREVO_DEAL_PIPELINE == '65ce1a5e59d96ff2630f06c8') {
-      // test value, already public in app/backend/.env.exemple
-      deal_stage = BrevoStatus.TestTransmitted
-    }
     return {
       envoy: domainUpdateAttributes.sentToOpportunityHub,
-      deal_stage: deal_stage
+      deal_stage: Config.BREVO_DEAL_PIPELINE == '65ce1a5e59d96ff2630f06c8' ? BrevoDealStatus.TestTransmitted : BrevoDealStatus.Transmitted
     }
   } else {
     return {

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
@@ -72,7 +72,7 @@ export interface DealUpdateAttributes {
 
 export enum BrevoStatus {
   Transmitted = '659d15cff01695.94588187',
-  TestTransmitted = 'UklHvFVBzoDyjoTwk0Oqnf8' // Etape = gagné pour tester le changement de statut.
+  TestTransmitted = 'UklHvFVBzoDyjoTwk0Oqnf8' // Statut "gagné" sur la pipeline de test
 }
 
 export enum BrevoCompanySize {

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
@@ -67,10 +67,10 @@ export interface DealAttributes {
 
 export interface DealUpdateAttributes {
   envoy: boolean
-  deal_stage?: string
+  deal_stage?: BrevoDealStatus
 }
 
-export enum BrevoStatus {
+export enum BrevoDealStatus {
   Transmitted = '659d15cff01695.94588187',
   TestTransmitted = 'UklHvFVBzoDyjoTwk0Oqnf8' // Statut "gagné" sur la pipeline de test
 }

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
@@ -67,6 +67,11 @@ export interface DealAttributes {
 
 export interface DealUpdateAttributes {
   envoy: boolean
+  deal_stage?: string
+}
+
+export enum BrevoStatus {
+  Transmitted = '659d15cff01695.94588187'
 }
 
 export enum BrevoCompanySize {

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
@@ -71,7 +71,8 @@ export interface DealUpdateAttributes {
 }
 
 export enum BrevoStatus {
-  Transmitted = '659d15cff01695.94588187'
+  Transmitted = '659d15cff01695.94588187',
+  TestTransmitted = 'UklHvFVBzoDyjoTwk0Oqnf8' // Etape = gagné pour tester le changement de statut.
 }
 
 export enum BrevoCompanySize {

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -13,6 +13,7 @@ import { Operators, ProgramType } from '@tee/data'
 import { Opportunity, OpportunityType } from '@tee/common'
 import { Project } from '@tee/data'
 import Monitor from '../../../../common/domain/monitoring/monitor'
+import { ProjectService } from '../../../../project/application/projectService'
 
 export class PlaceDesEntreprises extends OpportunityHubAbstract {
   protected readonly _baseUrl = Config.PDE_API_BASEURL
@@ -95,21 +96,20 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
       return false
     }
 
-    let tranmismissiblePrograms = 0
+    let transmissiblePrograms = 0
     for (const prevOpportunity of previousDailyOpportunities.value) {
       const prevProgram = new ProgramService().getById(prevOpportunity.id)
-      if (prevProgram === undefined) {
-        //we are working with a project, which we transmit to PDE and we have to count
-        tranmismissiblePrograms += 1
-      }
       if (prevProgram && this.support(prevProgram)) {
-        tranmismissiblePrograms += 1
+        transmissiblePrograms += 1
+      }
+      if (new ProjectService().getById(+prevOpportunity.id)) {
+        transmissiblePrograms += 1
       }
     }
 
     // The current opportunity being already created in brevo when we check the hub transmission, we count the current program.
     // The question is do we have MORE than one tranmissible program which indicates older tranmissions.
-    return tranmismissiblePrograms > 1
+    return transmissiblePrograms > 1
   }
 
   private _makeHeaders(token: string): RawAxiosRequestHeaders {

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -102,13 +102,13 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
       if (prevProgram && this.support(prevProgram)) {
         transmissiblePrograms += 1
       }
-      if (new ProjectService().getById(+prevOpportunity.id)) {
+      if (new ProjectService().getBySlug(prevOpportunity.id)) {
         transmissiblePrograms += 1
       }
     }
 
     // The current opportunity being already created in brevo when we check the hub transmission, we count the current program.
-    // The question is do we have MORE than one tranmissible program which indicates older tranmissions.
+    // The question is do we have MORE than one transmissible opportunity which indicates older tranmissions.
     return transmissiblePrograms > 1
   }
 

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -99,7 +99,7 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
     for (const prevOpportunity of previousDailyOpportunities.value) {
       const prevProgram = new ProgramService().getById(prevOpportunity.id)
       if (prevProgram === undefined) {
-        //we are working with a project, which are defined by CE
+        //we are working with a project, which we transmit to PDE and we have to count
         tranmismissiblePrograms += 1
       }
       if (prevProgram && this.support(prevProgram)) {

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -91,14 +91,12 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
 
   async reachedDailyContactTransmissionLimit(contact: number): Promise<boolean> {
     const previousDailyOpportunities = await new OpportunityService().getDailyOpportunitiesByContactId(contact)
-    console.log('previous opportunities', previousDailyOpportunities)
     if (previousDailyOpportunities.isErr) {
       return false
     }
 
     let tranmismissiblePrograms = 0
     for (const prevOpportunity of previousDailyOpportunities.value) {
-      console.log(prevOpportunity)
       const prevProgram = new ProgramService().getById(prevOpportunity.id)
       if (prevProgram === undefined) {
         //we are working with a project, which are defined by CE
@@ -108,7 +106,7 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
         tranmismissiblePrograms += 1
       }
     }
-    console.log('nombre de programmes précédemment détectés ', tranmismissiblePrograms)
+
     // The current opportunity being already created in brevo when we check the hub transmission, we count the current program.
     // The question is do we have MORE than one tranmissible program which indicates older tranmissions.
     return tranmismissiblePrograms > 1

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -91,17 +91,24 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
 
   async reachedDailyContactTransmissionLimit(contact: number): Promise<boolean> {
     const previousDailyOpportunities = await new OpportunityService().getDailyOpportunitiesByContactId(contact)
+    console.log('previous opportunities', previousDailyOpportunities)
     if (previousDailyOpportunities.isErr) {
       return false
     }
 
     let tranmismissiblePrograms = 0
     for (const prevOpportunity of previousDailyOpportunities.value) {
+      console.log(prevOpportunity)
       const prevProgram = new ProgramService().getById(prevOpportunity.id)
+      if (prevProgram === undefined) {
+        //we are working with a project, which are defined by CE
+        tranmismissiblePrograms += 1
+      }
       if (prevProgram && this.support(prevProgram)) {
         tranmismissiblePrograms += 1
       }
     }
+    console.log('nombre de programmes précédemment détectés ', tranmismissiblePrograms)
     // The current opportunity being already created in brevo when we check the hub transmission, we count the current program.
     // The question is do we have MORE than one tranmissible program which indicates older tranmissions.
     return tranmismissiblePrograms > 1

--- a/libs/backend-ddd/src/project/application/projectService.ts
+++ b/libs/backend-ddd/src/project/application/projectService.ts
@@ -1,0 +1,14 @@
+import { Project } from '@tee/data'
+import ProjectFeatures from '../domain/projectFeatures'
+
+export class ProjectService {
+  private _project: ProjectFeatures
+
+  public constructor() {
+    this._project = new ProjectFeatures()
+  }
+
+  public getById(id: number): Project | undefined {
+    return this._project.getById(id)
+  }
+}

--- a/libs/backend-ddd/src/project/application/projectService.ts
+++ b/libs/backend-ddd/src/project/application/projectService.ts
@@ -11,4 +11,7 @@ export class ProjectService {
   public getById(id: number): Project | undefined {
     return this._project.getById(id)
   }
+  public getBySlug(id: string): Project | undefined {
+    return this._project.getBySlug(id)
+  }
 }

--- a/libs/backend-ddd/src/project/domain/projectFeatures.ts
+++ b/libs/backend-ddd/src/project/domain/projectFeatures.ts
@@ -5,4 +5,8 @@ export default class ProjectFeatures {
   public getById(id: number): Project | undefined {
     return projects.find((project) => project.id === +id)
   }
+
+  public getBySlug(slug: string): Project | undefined {
+    return projects.find((project) => project.slug === slug)
+  }
 }

--- a/libs/backend-ddd/src/project/domain/projectFeatures.ts
+++ b/libs/backend-ddd/src/project/domain/projectFeatures.ts
@@ -1,0 +1,8 @@
+import { Project } from '@tee/data'
+import { projects } from '@tee/data/static'
+
+export default class ProjectFeatures {
+  public getById(id: number): Project | undefined {
+    return projects.find((project) => project.id === +id)
+  }
+}

--- a/libs/data/tools/brevoExport/brevoExport.py
+++ b/libs/data/tools/brevoExport/brevoExport.py
@@ -256,7 +256,7 @@ def define_structure_size(deal):
     """Get the structure size using all possible encoding of it."""
     size = ""
     if "Contact_TAILLE" in deal and deal["Contact_TAILLE"] != "":
-        workforce_to_type = {"1": "TPE", "2": "PME", "3": "PME", "4": "ETI,GE"}
+        workforce_to_type = {"1": "TPE", "2": "PME", "3": "PME", "4": "ETI,GE", "5": "EI"}
         size = workforce_to_type[deal["Contact_TAILLE"]]
     elif "autres_donnes" in deal and deal["autres_donnes"] != "":
         pattern = r"/ structure_sizes: (.+?) /"


### PR DESCRIPTION
La PR est fonctionnelle mais je ne suis pas super fan de son archi. 

L'idée est de modifier le statut sur brevo au lieu de la colonne envoyée (puis à terme de cacher la colonne envoyée sur le site Brevo).

"Problème" : le statut correspond à une ID dépendant de l'ID de la pipeline brevo.
Je considère que cet id n'est pas une donnée sensible et je l'ai donc hard codé. 
La solution proposée permet de ne pas dévoiler l'id de la pipeline de prod.

La solution proposé cassera si on modifie les pipeline utilisées sur brevo.
La seule solution pour que ce ne soit pas le cas serait de query brevo pour obtenir dynamiquement l'id mais ça augmente le nombre d'appel à des services externe et donc le temps des transaction ce qui ne me plait pas. 

Point annexes de la PR: 
- fix du script de récup des données avec l'ajout de la valeur "EI"
- fix de la méthode "reachedDailyTransmissionLimit" pour PDE avec l'ajout de la prise en compte des projets !
