### PR TITLE
Fix : Correction fil d'ariane

### DIFF
--- a/apps/web/src/components/TeeFooter.vue
+++ b/apps/web/src/components/TeeFooter.vue
@@ -187,7 +187,7 @@ const mainLinks = [
   },
   {
     label: 'Statistiques',
-    to: { name: RouteName.Statistiques }
+    to: { name: RouteName.Statistics }
   },
   {
     label: 'Ajouter une aide',

--- a/apps/web/src/components/catalog/CatalogPrograms.vue
+++ b/apps/web/src/components/catalog/CatalogPrograms.vue
@@ -22,6 +22,7 @@
       />
     </div>
     <div class="fr-grid-row fr-grid-row--center">
+      <TeeDsfrBreadcrumb />
       <div class="fr-container fr-m-0 fr-p-0 fr-pl-md-2v">
         <div class="fr-col-12 fr-col-md-10 fr-col-offset-md-2 fr-col-justify--left fr-my-3v">
           <ThemeFilter v-if="hasThemeFilter" />

--- a/apps/web/src/components/catalog/CatalogPrograms.vue
+++ b/apps/web/src/components/catalog/CatalogPrograms.vue
@@ -22,7 +22,7 @@
       />
     </div>
     <div class="fr-grid-row fr-grid-row--center">
-      <TeeDsfrBreadcrumb />
+      <TeeDsfrBreadcrumb v-if="!hasSpinner" />
       <div class="fr-container fr-m-0 fr-p-0 fr-pl-md-2v">
         <div class="fr-col-12 fr-col-md-10 fr-col-offset-md-2 fr-col-justify--left fr-my-3v">
           <ThemeFilter v-if="hasThemeFilter" />

--- a/apps/web/src/components/catalog/CatalogPrograms.vue
+++ b/apps/web/src/components/catalog/CatalogPrograms.vue
@@ -1,4 +1,5 @@
 <template>
+  <TeeDsfrBreadcrumb v-if="!hasSpinner" />
   <CatalogBanner>
     <template #title> Le catalogue des aides publiques à la transition écologique </template>
     <template #description>
@@ -22,7 +23,6 @@
       />
     </div>
     <div class="fr-grid-row fr-grid-row--center">
-      <TeeDsfrBreadcrumb v-if="!hasSpinner" />
       <div class="fr-container fr-m-0 fr-p-0 fr-pl-md-2v">
         <div class="fr-col-12 fr-col-md-10 fr-col-offset-md-2 fr-col-justify--left fr-my-3v">
           <ThemeFilter v-if="hasThemeFilter" />

--- a/apps/web/src/components/catalog/CatalogProjects.vue
+++ b/apps/web/src/components/catalog/CatalogProjects.vue
@@ -20,6 +20,7 @@
         :email="Contact.email"
       />
       <div v-else>
+        <TeeDsfrBreadcrumb />
         <div class="fr-col-12 fr-col-justify--left fr-mt-3v">
           <ThemeFilter />
         </div>

--- a/apps/web/src/components/catalog/CatalogProjects.vue
+++ b/apps/web/src/components/catalog/CatalogProjects.vue
@@ -20,7 +20,7 @@
         :email="Contact.email"
       />
       <div v-else>
-        <TeeDsfrBreadcrumb />
+        <TeeDsfrBreadcrumb class="fr-p-0" />
         <div class="fr-col-12 fr-col-justify--left fr-mt-3v">
           <ThemeFilter />
         </div>

--- a/apps/web/src/components/catalog/CatalogProjects.vue
+++ b/apps/web/src/components/catalog/CatalogProjects.vue
@@ -1,4 +1,5 @@
 <template>
+  <TeeDsfrBreadcrumb />
   <CatalogBanner>
     <template #title> Le catalogue des projets de transition écologique </template>
     <template #description> Accédez à la liste des projets de transition écologique destinées aux entreprises. </template>
@@ -20,7 +21,6 @@
         :email="Contact.email"
       />
       <div v-else>
-        <TeeDsfrBreadcrumb class="fr-p-0" />
         <div class="fr-col-12 fr-col-justify--left fr-mt-3v">
           <ThemeFilter />
         </div>

--- a/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
+++ b/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
@@ -10,6 +10,7 @@
 import type { DsfrBreadcrumbProps } from '@gouvminint/vue-dsfr'
 import { useNavigationStore } from '@/stores/navigation'
 import { useUsedTrackStore } from '@/stores/usedTrack'
+import { TrackId } from '@/types'
 import { RouteName } from '@/types/routeType'
 import { type RouteLocationRaw } from 'vue-router'
 interface Props {
@@ -42,20 +43,16 @@ const routeToBaseList: RouteLocationRaw = {
 }
 
 const breadcrumbs = computed(() => {
-  let baseLinks: { text: string; to: RouteLocationRaw | string }[] = [{ text: 'Accueil', to: '/' }]
+  const baseLinks: { text: string; to: RouteLocationRaw }[] = [{ text: 'Accueil', to: { name: RouteName.Homepage } }]
   if (!navigationStore.isStaticPage()) {
     baseLinks.push({ text: getListText(), to: routeToBaseList })
   }
   if (navigationStore.isQuestionnaire()) {
     const trackId = usedTrackStore.getPreviousCompletedUsedTrackId()
-    baseLinks = [
-      ...baseLinks.slice(0, 1),
-      {
-        text: 'Questionnaire',
-        to: trackId ? navigationStore.routeByTrackId(trackId) : '/questionnaire'
-      },
-      ...baseLinks.slice(1)
-    ]
+    baseLinks.splice(1, 0, {
+      text: 'Questionnaire',
+      to: navigationStore.routeByTrackId(trackId || TrackId.QuestionnaireRoute)
+    })
   }
   if (props.links) {
     return [...baseLinks, ...props.links]

--- a/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
+++ b/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="fr-container">
-    <DsfrBreadcrumb :links="allBreadcrumbs" />
+    <DsfrBreadcrumb
+      :links="allBreadcrumbs"
+      class="fr-mb-1-5v"
+    />
   </div>
 </template>
 <script setup lang="ts">
@@ -19,10 +22,14 @@ const isProgramCatalogDetail = navigationStore.isByRouteName(RouteName.CatalogPr
 const isProjectCatalogDetail = navigationStore.isByRouteName(RouteName.CatalogProjectDetail)
 const isCatalogDetail = isProgramCatalogDetail || isProjectCatalogDetail
 
+const isProgramCatalog = navigationStore.isCatalogPrograms()
+const isProjectCatalog = navigationStore.isCatalogProjects()
+const isCatalog = isProgramCatalog || isProjectCatalog
+
 const getListText = () => {
-  if (isProgramCatalogDetail) {
+  if (isProgramCatalogDetail || isProgramCatalog) {
     return 'Liste des dispositifs'
-  } else if (isProjectCatalogDetail) {
+  } else if (isProjectCatalogDetail || isProjectCatalog) {
     return 'Liste des projets'
   } else {
     return 'Vos résultats'
@@ -48,7 +55,7 @@ const allBreadcrumbs = computed<DsfrBreadcrumbProps['links']>(() => {
     { text: 'Accueil', to: '/' },
     { text: getListText(), to: routeToBaseList }
   ]
-  if (!isCatalogDetail) {
+  if (!isCatalogDetail && !isCatalog) {
     const trackId = usedTrackStore.getPreviousCompletedUsedTrackId()
     if (trackId) {
       baseLinks = baseLinks.toSpliced(1, 0, {

--- a/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
+++ b/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
@@ -48,17 +48,14 @@ const breadcrumbs = computed(() => {
   }
   if (navigationStore.isQuestionnaire()) {
     const trackId = usedTrackStore.getPreviousCompletedUsedTrackId()
-    if (trackId) {
-      baseLinks = baseLinks.toSpliced(1, 0, {
+    baseLinks = [
+      ...baseLinks.slice(0, 1),
+      {
         text: 'Questionnaire',
-        to: navigationStore.routeByTrackId(trackId)
-      })
-    } else {
-      baseLinks = baseLinks.toSpliced(1, 0, {
-        text: 'Questionnaire',
-        to: '/questionnaire'
-      })
-    }
+        to: trackId ? navigationStore.routeByTrackId(trackId) : '/questionnaire'
+      },
+      ...baseLinks.slice(1)
+    ]
   }
   if (props.links) {
     return [...baseLinks, ...props.links]

--- a/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
+++ b/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="fr-container">
     <DsfrBreadcrumb
-      :links="allBreadcrumbs"
+      :links="breadcrumbs"
       class="fr-mb-1-5v"
     />
   </div>
@@ -19,39 +19,17 @@ const props = defineProps<Props>()
 const navigationStore = useNavigationStore()
 const usedTrackStore = useUsedTrackStore()
 
-const isProgramCatalogDetail = navigationStore.isCatalogProgramDetail()
-const isProjectCatalogDetail = navigationStore.isCatalogProjectDetail()
-const isCatalogDetail = navigationStore.isCatalogDetail()
-
-const isProgramCatalog = navigationStore.isCatalogPrograms()
-const isProjectCatalog = navigationStore.isCatalogProjects()
-
-const isInfoPage = navigationStore.isByRouteName([
-  RouteName.Legal,
-  RouteName.PersonalData,
-  RouteName.Legal,
-  RouteName.Accessibility,
-  RouteName.Statistiques
-])
-const isQuestionnaire = navigationStore.isByRouteName([
-  RouteName.QuestionnaireResult,
-  RouteName.QuestionnaireResultDetail,
-  RouteName.ProgramFromProjectDetail,
-  RouteName.ProjectResultDetail
-])
 const getListText = () => {
-  if (isProgramCatalogDetail || isProgramCatalog) {
-    return 'Liste des dispositifs'
-  } else if (isProjectCatalogDetail || isProjectCatalog) {
-    return 'Liste des projets'
+  if (navigationStore.isCatalog()) {
+    return 'Liste des ' + (navigationStore.isCatalogAboutPrograms() ? 'dispositifs' : 'projets')
   } else {
     return 'Vos résultats'
   }
 }
 const getBaseRouteName = () => {
-  if (isProgramCatalogDetail) {
+  if (navigationStore.isCatalogProgramDetail()) {
     return RouteName.CatalogPrograms
-  } else if (isProjectCatalogDetail) {
+  } else if (navigationStore.isCatalogProjectDetail()) {
     return RouteName.CatalogProjects
   } else {
     return RouteName.QuestionnaireResult
@@ -60,15 +38,15 @@ const getBaseRouteName = () => {
 
 const routeToBaseList: RouteLocationRaw = {
   name: getBaseRouteName(),
-  query: isCatalogDetail ? undefined : navigationStore.query
+  query: navigationStore.isCatalogDetail() ? undefined : navigationStore.query
 }
 
-const allBreadcrumbs = computed(() => {
+const breadcrumbs = computed(() => {
   let baseLinks: { text: string; to: RouteLocationRaw | string }[] = [{ text: 'Accueil', to: '/' }]
-  if (!isInfoPage) {
+  if (!navigationStore.isStaticPage()) {
     baseLinks.push({ text: getListText(), to: routeToBaseList })
   }
-  if (isQuestionnaire) {
+  if (navigationStore.isQuestionnaire()) {
     const trackId = usedTrackStore.getPreviousCompletedUsedTrackId()
     if (trackId) {
       baseLinks = baseLinks.toSpliced(1, 0, {

--- a/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
+++ b/apps/web/src/components/element/TeeDsfrBreadcrumb.vue
@@ -25,10 +25,20 @@ const isCatalogDetail = navigationStore.isCatalogDetail()
 
 const isProgramCatalog = navigationStore.isCatalogPrograms()
 const isProjectCatalog = navigationStore.isCatalogProjects()
-const isCatalog = navigationStore.isCatalog()
 
-const isStatPage = navigationStore.isByRouteName(RouteName.Statistiques)
-
+const isInfoPage = navigationStore.isByRouteName([
+  RouteName.Legal,
+  RouteName.PersonalData,
+  RouteName.Legal,
+  RouteName.Accessibility,
+  RouteName.Statistiques
+])
+const isQuestionnaire = navigationStore.isByRouteName([
+  RouteName.QuestionnaireResult,
+  RouteName.QuestionnaireResultDetail,
+  RouteName.ProgramFromProjectDetail,
+  RouteName.ProjectResultDetail
+])
 const getListText = () => {
   if (isProgramCatalogDetail || isProgramCatalog) {
     return 'Liste des dispositifs'
@@ -55,10 +65,10 @@ const routeToBaseList: RouteLocationRaw = {
 
 const allBreadcrumbs = computed(() => {
   let baseLinks: { text: string; to: RouteLocationRaw | string }[] = [{ text: 'Accueil', to: '/' }]
-  if (!isStatPage) {
+  if (!isInfoPage) {
     baseLinks.push({ text: getListText(), to: routeToBaseList })
   }
-  if (!isCatalogDetail && !isCatalog && !isStatPage) {
+  if (isQuestionnaire) {
     const trackId = usedTrackStore.getPreviousCompletedUsedTrackId()
     if (trackId) {
       baseLinks = baseLinks.toSpliced(1, 0, {
@@ -71,8 +81,6 @@ const allBreadcrumbs = computed(() => {
         to: '/questionnaire'
       })
     }
-  } else if (isStatPage) {
-    baseLinks.push({ text: 'Statistiques', to: '/stats' })
   }
   if (props.links) {
     return [...baseLinks, ...props.links]

--- a/apps/web/src/components/objective/ThemeSelect.vue
+++ b/apps/web/src/components/objective/ThemeSelect.vue
@@ -16,7 +16,7 @@ import { useUsedTrackStore } from '@/stores/usedTrack'
 import type { TrackOptionItem } from '@/types'
 import { computed } from 'vue'
 import { Theme } from '@/utils/theme'
-import { ProgramData, Color, Objective } from '@/types'
+import { ProgramData, Color, Objective, TrackId } from '@/types'
 import { Project } from '@tee/data'
 import { useProjectStore } from '@/stores/project'
 import { useProgramStore } from '@/stores/program'
@@ -86,15 +86,20 @@ const selectOption = (opt: string | undefined) => {
 const hasError = ref<boolean>(false)
 
 onBeforeMount(async () => {
-  useNavigationStore().hasSpinner = true
-  const projectResult = await projectStore.projects
-  const programResult = await programStore.programsByUsedTracks
-  if (programResult.isOk && projectResult.isOk) {
-    projects.value = projectResult.value
-    programs.value = programResult.value
+  const selectedOptionValue = useNavigationStore().query[TrackId.Goals]
+  if (selectedOptionValue) {
+    selectOption(selectedOptionValue as string)
   } else {
-    hasError.value = true
+    useNavigationStore().hasSpinner = true
+    const projectResult = await projectStore.projects
+    const programResult = await programStore.programsByUsedTracks
+    if (programResult.isOk && projectResult.isOk) {
+      projects.value = projectResult.value
+      programs.value = programResult.value
+    } else {
+      hasError.value = true
+    }
+    useNavigationStore().hasSpinner = false
   }
-  useNavigationStore().hasSpinner = false
 })
 </script>

--- a/apps/web/src/components/objective/ThemeSelect.vue
+++ b/apps/web/src/components/objective/ThemeSelect.vue
@@ -16,7 +16,7 @@ import { useUsedTrackStore } from '@/stores/usedTrack'
 import type { TrackOptionItem } from '@/types'
 import { computed } from 'vue'
 import { Theme } from '@/utils/theme'
-import { ProgramData, Color, Objective, TrackId } from '@/types'
+import { ProgramData, Color, Objective } from '@/types'
 import { Project } from '@tee/data'
 import { useProjectStore } from '@/stores/project'
 import { useProgramStore } from '@/stores/program'
@@ -86,20 +86,15 @@ const selectOption = (opt: string | undefined) => {
 const hasError = ref<boolean>(false)
 
 onBeforeMount(async () => {
-  const selectedOptionValue = useNavigationStore().query[TrackId.Goals]
-  if (selectedOptionValue) {
-    selectOption(selectedOptionValue as string)
+  useNavigationStore().hasSpinner = true
+  const projectResult = await projectStore.projects
+  const programResult = await programStore.programsByUsedTracks
+  if (programResult.isOk && projectResult.isOk) {
+    projects.value = projectResult.value
+    programs.value = programResult.value
   } else {
-    useNavigationStore().hasSpinner = true
-    const projectResult = await projectStore.projects
-    const programResult = await programStore.programsByUsedTracks
-    if (programResult.isOk && projectResult.isOk) {
-      projects.value = projectResult.value
-      programs.value = programResult.value
-    } else {
-      hasError.value = true
-    }
-    useNavigationStore().hasSpinner = false
+    hasError.value = true
   }
+  useNavigationStore().hasSpinner = false
 })
 </script>

--- a/apps/web/src/pages/TeeAccessibilityPage.vue
+++ b/apps/web/src/pages/TeeAccessibilityPage.vue
@@ -4,6 +4,10 @@
     class="fr-container fr-my-8w"
   >
     <div class="fr-grid-row--gutters">
+      <TeeDsfrBreadcrumb
+        class="fr-p-0"
+        :links="[{ text: 'Accessibilité', to: '/accessibilite' }]"
+      />
       <div class="fr-grid-col">
         <h1>Politique d’accessibilité - RGAA</h1>
         <p>

--- a/apps/web/src/pages/TeeAccessibilityPage.vue
+++ b/apps/web/src/pages/TeeAccessibilityPage.vue
@@ -6,7 +6,7 @@
     <div class="fr-grid-row--gutters">
       <TeeDsfrBreadcrumb
         class="fr-p-0"
-        :links="[{ text: 'Accessibilité', to: '/accessibilite' }]"
+        :links="[{ text: 'Accessibilité', to: RouteName.Accessibility }]"
       />
       <div class="fr-grid-col">
         <h1>Politique d’accessibilité - RGAA</h1>
@@ -121,5 +121,6 @@
 // console.log(`TeeAccessibilityPage > FUNCTION_NAME > MSG_OR_VALUE :`)
 
 import ContactMail from '@/components/contact/ContactMail.vue'
+import { RouteName } from '@/types'
 import Contact from '@/utils/contact'
 </script>

--- a/apps/web/src/pages/TeeAccessibilityPage.vue
+++ b/apps/web/src/pages/TeeAccessibilityPage.vue
@@ -2,7 +2,7 @@
   <TeeDsfrBreadcrumb :links="[{ text: 'Accessibilité', to: RouteName.Accessibility }]" />
   <div
     id="simple-page"
-    class="fr-container fr-my-8w"
+    class="fr-container fr-mb-8w"
   >
     <div class="fr-grid-row">
       <div class="fr-grid-col">

--- a/apps/web/src/pages/TeeAccessibilityPage.vue
+++ b/apps/web/src/pages/TeeAccessibilityPage.vue
@@ -1,13 +1,10 @@
 <template>
+  <TeeDsfrBreadcrumb :links="[{ text: 'Accessibilité', to: RouteName.Accessibility }]" />
   <div
     id="simple-page"
     class="fr-container fr-my-8w"
   >
-    <div class="fr-grid-row--gutters">
-      <TeeDsfrBreadcrumb
-        class="fr-p-0"
-        :links="[{ text: 'Accessibilité', to: RouteName.Accessibility }]"
-      />
+    <div class="fr-grid-row">
       <div class="fr-grid-col">
         <h1>Politique d’accessibilité - RGAA</h1>
         <p>

--- a/apps/web/src/pages/TeeCatalogPage.vue
+++ b/apps/web/src/pages/TeeCatalogPage.vue
@@ -13,6 +13,6 @@ import { useNavigationStore } from '@/stores/navigation'
 
 const navigationStore = useNavigationStore()
 const isCatalog = computed(() => {
-  return navigationStore.isCatalog()
+  return navigationStore.isCatalogList()
 })
 </script>

--- a/apps/web/src/pages/TeeLegalPage.vue
+++ b/apps/web/src/pages/TeeLegalPage.vue
@@ -5,7 +5,7 @@
   >
     <div class="fr-grid-row--gutters">
       <TeeDsfrBreadcrumb
-        :links="[{ text: 'Mentions légales', to: '/mentions-legales' }]"
+        :links="[{ text: 'Mentions légales', to: RouteName.Legal }]"
         class="fr-p-0"
       />
       <div class="fr-grid-col">

--- a/apps/web/src/pages/TeeLegalPage.vue
+++ b/apps/web/src/pages/TeeLegalPage.vue
@@ -2,7 +2,7 @@
   <TeeDsfrBreadcrumb :links="[{ text: 'Mentions légales', to: RouteName.Legal }]" />
   <div
     id="simple-page"
-    class="fr-container fr-my-8w"
+    class="fr-container fr-mb-8w"
   >
     <div class="fr-grid-row">
       <div class="fr-grid-col">

--- a/apps/web/src/pages/TeeLegalPage.vue
+++ b/apps/web/src/pages/TeeLegalPage.vue
@@ -1,13 +1,10 @@
 <template>
+  <TeeDsfrBreadcrumb :links="[{ text: 'Mentions légales', to: RouteName.Legal }]" />
   <div
     id="simple-page"
     class="fr-container fr-my-8w"
   >
-    <div class="fr-grid-row--gutters">
-      <TeeDsfrBreadcrumb
-        :links="[{ text: 'Mentions légales', to: RouteName.Legal }]"
-        class="fr-p-0"
-      />
+    <div class="fr-grid-row">
       <div class="fr-grid-col">
         <h1>Mentions légales</h1>
         <p>Mis à jour le 17 juin 2024</p>

--- a/apps/web/src/pages/TeeLegalPage.vue
+++ b/apps/web/src/pages/TeeLegalPage.vue
@@ -4,6 +4,10 @@
     class="fr-container fr-my-8w"
   >
     <div class="fr-grid-row--gutters">
+      <TeeDsfrBreadcrumb
+        :links="[{ text: 'Mentions légales', to: '/mentions-legales' }]"
+        class="fr-p-0"
+      />
       <div class="fr-grid-col">
         <h1>Mentions légales</h1>
         <p>Mis à jour le 17 juin 2024</p>

--- a/apps/web/src/pages/TeePersonalDataPage.vue
+++ b/apps/web/src/pages/TeePersonalDataPage.vue
@@ -1,13 +1,10 @@
 <template>
+  <TeeDsfrBreadcrumb :links="[{ text: 'Données personnelles', to: RouteName.PersonalData }]" />
   <div
     id="simple-page"
     class="fr-container fr-my-8w"
   >
-    <div class="fr-grid-row--gutters">
-      <TeeDsfrBreadcrumb
-        :links="[{ text: 'Données personnelles', to: RouteName.PersonalData }]"
-        class="fr-p-0"
-      />
+    <div class="fr-grid-row">
       <div class="fr-grid-col">
         <h1>Données personnelles (et gestion des cookies)</h1>
         <p>

--- a/apps/web/src/pages/TeePersonalDataPage.vue
+++ b/apps/web/src/pages/TeePersonalDataPage.vue
@@ -4,6 +4,10 @@
     class="fr-container fr-my-8w"
   >
     <div class="fr-grid-row--gutters">
+      <TeeDsfrBreadcrumb
+        :links="[{ text: 'Données personnelles', to: '/donnees-personnelles' }]"
+        class="fr-p-0"
+      />
       <div class="fr-grid-col">
         <h1>Données personnelles (et gestion des cookies)</h1>
         <p>

--- a/apps/web/src/pages/TeePersonalDataPage.vue
+++ b/apps/web/src/pages/TeePersonalDataPage.vue
@@ -5,7 +5,7 @@
   >
     <div class="fr-grid-row--gutters">
       <TeeDsfrBreadcrumb
-        :links="[{ text: 'Données personnelles', to: '/donnees-personnelles' }]"
+        :links="[{ text: 'Données personnelles', to: RouteName.PersonalData }]"
         class="fr-p-0"
       />
       <div class="fr-grid-col">

--- a/apps/web/src/pages/TeePersonalDataPage.vue
+++ b/apps/web/src/pages/TeePersonalDataPage.vue
@@ -2,7 +2,7 @@
   <TeeDsfrBreadcrumb :links="[{ text: 'Données personnelles', to: RouteName.PersonalData }]" />
   <div
     id="simple-page"
-    class="fr-container fr-my-8w"
+    class="fr-container fr-mb-8w"
   >
     <div class="fr-grid-row">
       <div class="fr-grid-col">

--- a/apps/web/src/pages/TeeStatPage.vue
+++ b/apps/web/src/pages/TeeStatPage.vue
@@ -1,9 +1,6 @@
 <template>
+  <TeeDsfrBreadcrumb :links="[{ text: 'Statistiques', to: RouteName.Statistics }]" />
   <div class="fr-container fr-my-8w">
-    <TeeDsfrBreadcrumb
-      class="fr-p-0"
-      :links="[{ text: 'Statistiques', to: RouteName.Statistics }]"
-    />
     <div class="fr-mb-5w">
       <h1 class="fr-mb-3w">Statistiques d'usage</h1>
       <p>

--- a/apps/web/src/pages/TeeStatPage.vue
+++ b/apps/web/src/pages/TeeStatPage.vue
@@ -2,7 +2,7 @@
   <div class="fr-container fr-my-8w">
     <TeeDsfrBreadcrumb
       class="fr-p-0"
-      :links="[{ text: 'Statistiques', to: '/stats' }]"
+      :links="[{ text: 'Statistiques', to: RouteName.Statistics }]"
     />
     <div class="fr-mb-5w">
       <h1 class="fr-mb-3w">Statistiques d'usage</h1>
@@ -104,7 +104,7 @@
 import { ref, onMounted } from 'vue'
 import Chart from 'chart.js/auto'
 import StatsApi from '@/service/api/statsApi'
-import { CalloutType, StatsData } from '@/types'
+import { CalloutType, RouteName, StatsData } from '@/types'
 
 const statsData = ref<StatsData | null>(null)
 const chartCanvas = ref<HTMLCanvasElement | null>(null)

--- a/apps/web/src/pages/TeeStatPage.vue
+++ b/apps/web/src/pages/TeeStatPage.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="fr-container fr-my-8w">
+    <TeeDsfrBreadcrumb class="fr-p-0" />
     <div class="fr-mb-5w">
       <h1 class="fr-mb-3w">Statistiques d'usage</h1>
       <p>

--- a/apps/web/src/pages/TeeStatPage.vue
+++ b/apps/web/src/pages/TeeStatPage.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="fr-container fr-my-8w">
-    <TeeDsfrBreadcrumb class="fr-p-0" />
+    <TeeDsfrBreadcrumb
+      class="fr-p-0"
+      :links="[{ text: 'Statistiques', to: '/stats' }]"
+    />
     <div class="fr-mb-5w">
       <h1 class="fr-mb-3w">Statistiques d'usage</h1>
       <p>

--- a/apps/web/src/pages/TeeStatPage.vue
+++ b/apps/web/src/pages/TeeStatPage.vue
@@ -1,6 +1,6 @@
 <template>
   <TeeDsfrBreadcrumb :links="[{ text: 'Statistiques', to: RouteName.Statistics }]" />
-  <div class="fr-container fr-my-8w">
+  <div class="fr-container fr-mb-8w">
     <div class="fr-mb-5w">
       <h1 class="fr-mb-3w">Statistiques d'usage</h1>
       <p>

--- a/apps/web/src/router/routes.ts
+++ b/apps/web/src/router/routes.ts
@@ -135,7 +135,7 @@ export const routes = [
   },
   {
     path: '/accessibilite',
-    name: 'accessibility',
+    name: RouteName.Accessibility,
     component: TeeAccessibilityPage as Component
   },
   {

--- a/apps/web/src/router/routes.ts
+++ b/apps/web/src/router/routes.ts
@@ -145,7 +145,7 @@ export const routes = [
   },
   {
     path: '/stats',
-    name: RouteName.Statistiques,
+    name: RouteName.Statistics,
     component: TeeStatPage as Component
   },
   {

--- a/apps/web/src/stores/navigation.ts
+++ b/apps/web/src/stores/navigation.ts
@@ -91,12 +91,36 @@ export const useNavigationStore = defineStore('navigation', () => {
     return isByRouteName(RouteName.CatalogProgramDetail)
   }
 
-  function isCatalog() {
+  function isCatalogAboutPrograms() {
+    return isCatalogPrograms() || isCatalogProgramDetail()
+  }
+
+  function isCatalogList() {
     return isByRouteName([RouteName.CatalogPrograms, RouteName.CatalogProjects])
   }
 
   function isCatalogDetail() {
-    return isByRouteName([RouteName.CatalogProgramDetail, RouteName.CatalogProjectDetail])
+    return isCatalogProgramDetail() || isCatalogProjectDetail()
+  }
+
+  function isCatalog() {
+    return isCatalogDetail() || isCatalogList()
+  }
+
+  function isQuestionnaire() {
+    return isQuestionnaireResult() || isQuestionnaireResultDetail()
+  }
+
+  function isQuestionnaireResult() {
+    return isByRouteName(RouteName.QuestionnaireResult)
+  }
+
+  function isQuestionnaireResultDetail() {
+    return isByRouteName([RouteName.QuestionnaireResultDetail, RouteName.ProgramFromProjectDetail, RouteName.ProjectResultDetail])
+  }
+
+  function isStaticPage() {
+    return !isQuestionnaire() && !isCatalog()
   }
 
   function isByRouteName(routeName: string | string[]) {
@@ -175,15 +199,21 @@ export const useNavigationStore = defineStore('navigation', () => {
     searchParams,
     tabSelectedOnList,
     hasSpinner,
+    isCatalog,
+    isCatalogAboutPrograms,
     isCatalogPrograms,
     isCatalogProjects,
     isCatalogProjectDetail,
     isCatalogProgramDetail,
-    isCatalog,
+    isCatalogList,
     isCatalogDetail,
     isByRouteName,
     resetSearchParams,
     setRouter,
+    isQuestionnaire,
+    isQuestionnaireResult,
+    isQuestionnaireResultDetail,
+    isStaticPage,
     setRoute,
     setSearchParams,
     updateSearchParam,

--- a/apps/web/src/stores/navigation.ts
+++ b/apps/web/src/stores/navigation.ts
@@ -87,8 +87,16 @@ export const useNavigationStore = defineStore('navigation', () => {
     return isByRouteName(RouteName.CatalogProjectDetail)
   }
 
+  function isCatalogProgramDetail() {
+    return isByRouteName(RouteName.CatalogProgramDetail)
+  }
+
   function isCatalog() {
     return isByRouteName([RouteName.CatalogPrograms, RouteName.CatalogProjects])
+  }
+
+  function isCatalogDetail() {
+    return isByRouteName([RouteName.CatalogProgramDetail, RouteName.CatalogProjectDetail])
   }
 
   function isByRouteName(routeName: string | string[]) {
@@ -170,7 +178,9 @@ export const useNavigationStore = defineStore('navigation', () => {
     isCatalogPrograms,
     isCatalogProjects,
     isCatalogProjectDetail,
+    isCatalogProgramDetail,
     isCatalog,
+    isCatalogDetail,
     isByRouteName,
     resetSearchParams,
     setRouter,

--- a/apps/web/src/types/routeType.ts
+++ b/apps/web/src/types/routeType.ts
@@ -14,5 +14,6 @@ export enum RouteName {
   QuestionnaireResultDetail = 'questionnaire-result-detail',
   ProgramFromProjectDetail = 'program-from-project-detail',
   ProjectResultDetail = 'questionnaire-project-result-detail',
-  Statistiques = 'statistics'
+  Statistiques = 'statistics',
+  Accessibility = 'accessibility'
 }

--- a/apps/web/src/types/routeType.ts
+++ b/apps/web/src/types/routeType.ts
@@ -14,6 +14,6 @@ export enum RouteName {
   QuestionnaireResultDetail = 'questionnaire-result-detail',
   ProgramFromProjectDetail = 'program-from-project-detail',
   ProjectResultDetail = 'questionnaire-project-result-detail',
-  Statistiques = 'statistics',
+  Statistics = 'statistics',
   Accessibility = 'accessibility'
 }


### PR DESCRIPTION
- ajout du breadcrumb dans les catalogues projets + programs + page legale + page statistique + page données perso + page accessibilité 
- fix du lien questionnaire >> rollback sur le onBeforeMount du composant ThemeSelect (ajoutées pour le CTA pour si on a déjà une valeur d'objectif enregistrée, on passe directement à l'étape résultats ce qui causait le probleme au niveau du breadcrumb)
- adaptation du composant pour afficher les bons intitulés selon la route
- ajout margin bottom 
- remplacement de la méthode toSPliced par du slice dans teedsfrbreadcrumb pour résoudre le probleme de compatibilité (erreur sentry)