### PR TITLE
rollback: brevo status update

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -17,7 +17,6 @@ BREVO_SANDBOX=true
 # https://developers.brevo.com/reference/get_crm-pipeline-details-all
 # Example value : test pipeline
 BREVO_DEAL_PIPELINE=65ce1a5e59d96ff2630f06c8
-# warning there is a hard copy of this value in the codebase
 
 # Where should the brevo contacts be created (example value : test list)
 BREVO_LIST_IDS=4

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -8,8 +8,7 @@ import {
   DealUpdateAttributes,
   BrevoPostDealPayload,
   BrevoDealResponse,
-  BrevoDealItem,
-  BrevoDealStatus
+  BrevoDealItem
 } from './types'
 import Config from '../../../../config'
 import { QuestionnaireRoute } from '@tee/common'
@@ -104,15 +103,8 @@ const convertDomainToBrevoDeal = (domainAttributes: OpportunityWithOperatorConta
 }
 
 const convertDomainToBrevoDealUpdate = (domainUpdateAttributes: OpportunityUpdateAttributes): DealUpdateAttributes => {
-  if (domainUpdateAttributes.sentToOpportunityHub) {
-    return {
-      envoy: domainUpdateAttributes.sentToOpportunityHub,
-      deal_stage: Config.BREVO_DEAL_PIPELINE == '65ce1a5e59d96ff2630f06c8' ? BrevoDealStatus.TestTransmitted : BrevoDealStatus.Transmitted
-    }
-  } else {
-    return {
-      envoy: domainUpdateAttributes.sentToOpportunityHub
-    }
+  return {
+    envoy: domainUpdateAttributes.sentToOpportunityHub
   }
 }
 

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
@@ -67,12 +67,6 @@ export interface DealAttributes {
 
 export interface DealUpdateAttributes {
   envoy: boolean
-  deal_stage?: BrevoDealStatus
-}
-
-export enum BrevoDealStatus {
-  Transmitted = '659d15cff01695.94588187',
-  TestTransmitted = 'UklHvFVBzoDyjoTwk0Oqnf8' // Statut "gagné" sur la pipeline de test
 }
 
 export enum BrevoCompanySize {


### PR DESCRIPTION
Suite à un revirement de la personne en charge du suivi des opportunité BREVO, rollback du changement sur la mise à jour du statut. 