### PR TITLE
refactor: modify project lists to show or hide elements conditionally

### DIFF
--- a/apps/web/src/components/project/list/ProjectList.vue
+++ b/apps/web/src/components/project/list/ProjectList.vue
@@ -2,7 +2,10 @@
   <!--  LIST OF PROJECT CARDS-->
 
   <!--  Project counter -->
-  <div class="fr-grid-row fr-grid-row--center">
+  <div
+    v-if="!allTagSelected"
+    class="fr-grid-row fr-grid-row--center fr-mt-2v fr-mt-md-3v"
+  >
     <div class="fr-container">
       <div class="fr-col-12 fr-col-md-10 fr-col-offset-md-2 fr-text--blue-france tee-font-style--italic">
         <TeeCounterResult :to-count="sortedProjects" />
@@ -124,8 +127,11 @@ const programStore = useProgramStore()
 
 const resume: string = Translation.t('project.result.resume', {
   effectif: Translation.t('enterprise.structureSize.' + TrackStructure.getSize()),
-  secteur: TrackStructure.getSectorShortLabel(),
-  region: TrackStructure.getRegion()
+  secteur: TrackStructure.getSectorShortLabel()
+})
+
+const allTagSelected = computed(() => {
+  return programStore.programFilters.objectiveTypeSelected === ''
 })
 
 const hasPriorityProjects = computed(() => {

--- a/apps/web/src/components/project/list/ProjectList.vue
+++ b/apps/web/src/components/project/list/ProjectList.vue
@@ -3,7 +3,7 @@
 
   <!--  Project counter -->
   <div
-    v-if="!allTagSelected"
+    v-if="programStore.hasObjectiveTypeSelected()"
     class="fr-grid-row fr-grid-row--center fr-mt-2v fr-mt-md-3v"
   >
     <div class="fr-container">
@@ -128,10 +128,6 @@ const programStore = useProgramStore()
 const resume: string = Translation.t('project.result.resume', {
   effectif: Translation.t('enterprise.structureSize.' + TrackStructure.getSize()),
   secteur: TrackStructure.getSectorShortLabel()
-})
-
-const allTagSelected = computed(() => {
-  return programStore.programFilters.objectiveTypeSelected === ''
 })
 
 const hasPriorityProjects = computed(() => {

--- a/apps/web/src/components/project/list/ProjectList.vue
+++ b/apps/web/src/components/project/list/ProjectList.vue
@@ -29,7 +29,7 @@
         </div>
         <div class="fr-col-10">
           <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--left">
-            <div class="fr-col-12 fr-pt-2w fr-text--bold fr-text--blue-france">
+            <div class="fr-col-12 fr-pt-3w fr-pb-2v fr-text--bold fr-text--blue-france">
               {{ resume }}
             </div>
             <router-link

--- a/apps/web/src/components/questionnaire/result/list/ResultProjectList.vue
+++ b/apps/web/src/components/questionnaire/result/list/ResultProjectList.vue
@@ -1,11 +1,13 @@
 <template>
   <!-- PROGRAMS AS LIST OF CARDS -->
   <div class="fr-container--fluid fr-container--fluid--no-overflow">
-    <div class="fr-grid-row fr-grid-row--center">
+    <div
+      v-if="showNoResults"
+      class="fr-grid-row fr-grid-row--center"
+    >
       <div class="fr-container fr-mt-3v">
         <div class="fr-col-12 fr-col-md-10 fr-col-offset-md-2 fr-col-justify--center">
           <ResultListNoResults
-            v-if="showNoResults"
             :has-error="hasError"
             message="Aucune idée d’action n’a pu être identifiée sur cette thématique..."
             :count-items="countProjects"

--- a/apps/web/src/translations/fr/project.ts
+++ b/apps/web/src/translations/fr/project.ts
@@ -3,7 +3,7 @@ const projectFrDict = {
     studyPrograms: 'Pour étudier votre projet :',
     financePrograms: 'Pour financer votre investissement :',
     result: {
-      resume: 'Voici les actions par lesquelles commencer pour votre {effectif} du secteur {secteur} en région {region} :'
+      resume: 'Voici les actions par lesquelles commencer pour votre {effectif} du secteur {secteur} :'
     },
     form: {
       needs: `Bonjour,


### PR DESCRIPTION
- ajoute une conditions pour afficher le counter des projets uniquement si un theme spécifique est séléctionné dans les tags
- modifie le condition d'affichage du composant ResultListNoResults pour éviter de surcharger le dom avec des div vides inutiles et qui poluent le spacing avec d'éventuelle classes css
- met à jour le texte de résumé pour la page de résultat des projets en supprimant la mention de la région

lien de test: https://tee-preprod-pr1069.osc-fr1.scalingo.io/

close #967 