### PR TITLE
fix: add payload on monitoring exception from bpi api

### DIFF
--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/bpiFrance.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/bpi/bpiFrance.ts
@@ -48,13 +48,13 @@ export class BpiFrance extends OpportunityHubAbstract {
     if (opportunity.type === OpportunityType.Project) {
       return Maybe.of(Error("BPI shouldn't transfer be transfered Project type opportunities."))
     }
+    const contactPayloadDTO = new opportunityPayloadDTO(opportunity, programOrProject as ProgramType).getPayload()
     try {
       const tokenResult = await this._getToken()
       if (tokenResult.isErr) {
         return Maybe.of(tokenResult.error)
       }
 
-      const contactPayloadDTO = new opportunityPayloadDTO(opportunity, programOrProject as ProgramType).getPayload()
       const response = await this.axios.post(this._contactUrl, contactPayloadDTO, {
         headers: AxiosHeaders.makeBearerHeader(tokenResult.value.access_token)
       })
@@ -65,7 +65,7 @@ export class BpiFrance extends OpportunityHubAbstract {
         return Maybe.of(new Error("Erreur à la création d'une opportunité chez BPI durant l'appel BPI. HTTP CODE:" + response.status))
       }
     } catch (exception: unknown) {
-      Monitor.exception(ensureError(exception))
+      Monitor.exception(ensureError(exception), { ...contactPayloadDTO })
       return Maybe.of(handleException(exception))
     }
   }


### PR DESCRIPTION
Ajout du playload de pour l'api bpi dans le monitoring d'exception

Permet d'avoir le detail du payload dans sentry car il manque ici par exemple

https://sentry.incubateur.net/organizations/betagouv/issues/119550/?environment=prod&project=-1&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=3