### PR TITLE
fix: add canonical url on program details from project detail page (catalog)

### DIFF
--- a/apps/web/src/components/program/detail/ProgramDetail.vue
+++ b/apps/web/src/components/program/detail/ProgramDetail.vue
@@ -307,6 +307,20 @@ onBeforeMount(async () => {
     linkedProjects.value = Program.getLinkedProjects(program.value, projectResult.value)
   }
 
+  if (program.value) {
+    if (navigationStore.isByRouteName(RouteName.CatalogProgramFromCatalogProjectDetail)) {
+      useHead({
+        link: [
+          {
+            rel: 'canonical',
+            href: navigationStore.getAbsoluteUrlByRouteName(RouteName.CatalogProgramDetail, {
+              programId: program.value.id
+            })
+          }
+        ]
+      })
+    }
+  }
   useSeoMeta(MetaSeo.get(program.value?.titre, program.value?.description, program.value?.illustration))
 
   useNavigationStore().hasSpinner = false

--- a/apps/web/src/components/program/detail/ProgramDetail.vue
+++ b/apps/web/src/components/program/detail/ProgramDetail.vue
@@ -307,20 +307,19 @@ onBeforeMount(async () => {
     linkedProjects.value = Program.getLinkedProjects(program.value, projectResult.value)
   }
 
-  if (program.value) {
-    if (navigationStore.isByRouteName(RouteName.CatalogProgramFromCatalogProjectDetail)) {
-      useHead({
-        link: [
-          {
-            rel: 'canonical',
-            href: navigationStore.getAbsoluteUrlByRouteName(RouteName.CatalogProgramDetail, {
-              programId: program.value.id
-            })
-          }
-        ]
-      })
-    }
+  if (program.value && navigationStore.isByRouteName(RouteName.CatalogProgramFromCatalogProjectDetail)) {
+    useHead({
+      link: [
+        {
+          rel: 'canonical',
+          href: navigationStore.getAbsoluteUrlByRouteName(RouteName.CatalogProgramDetail, {
+            programId: program.value.id
+          })
+        }
+      ]
+    })
   }
+
   useSeoMeta(MetaSeo.get(program.value?.titre, program.value?.description, program.value?.illustration))
 
   useNavigationStore().hasSpinner = false

--- a/apps/web/src/utils/metaSeo.ts
+++ b/apps/web/src/utils/metaSeo.ts
@@ -1,3 +1,5 @@
+import { UseSeoMetaInput } from '@unhead/vue'
+
 export class MetaSeo {
   private static readonly _baseTitle = 'Transition écologique des TPE & PME'
   private static readonly _defaultTitle = 'Transition écologique - Aides et financements TPE & PME'
@@ -5,7 +7,7 @@ export class MetaSeo {
   private static readonly _defaultDescription =
     'Service public pour les entreprises : Accédez simplement aux aides, accompagnements et financements pour réduire votre impact environnemental.'
 
-  static readonly get = (title?: string, description?: string, image?: string) => {
+  static readonly get = (title?: string, description?: string, image?: string): UseSeoMetaInput => {
     return this._buildMeta(this._title(title), this._image(image), this._description(description))
   }
 
@@ -26,7 +28,7 @@ export class MetaSeo {
     return location.origin + (image ?? this._defaultImage)
   }
 
-  private static _buildMeta(title: string, image: string, description?: string) {
+  private static _buildMeta(title: string, image: string, description?: string): UseSeoMetaInput {
     return {
       title: title,
       description: description,


### PR DESCRIPTION

#### Prise en compte de l'url canonical pour éviter les doublons lors que référencements SEO
- *[`apps/web/src/components/program/detail/ProgramDetail.vue`](diffhunk://#diff-d392d63033eccce730c3f9948f149ea8a5670fa8dc7b28d18f8f5e8bc23a0161R310-R323)*: Ajout de l'url canonical en  utilisant `useHead` quand on est sur la route `CatalogProgramFromCatalogProjectDetail`

#### typage du **MetaSeo** :

* [`apps/web/src/utils/metaSeo.ts`](diffhunk://#diff-ddd425e297e34ac1144d4c8a70e2314b97825e95a9219fa62a542692f134732eR1-R10) : Importation de `UseSeoMetaInput` et mise à jour des méthodes `get` et `_buildMeta` pour retourner le type `UseSeoMetaInput`. [[1]](diffhunk://#diff-ddd425e297e34ac1144d4c8a70e2314b97825e95a9219fa62a542692f134732eR1-R10) [[2]](diffhunk://#diff-ddd425e297e34ac1144d4c8a70e2314b97825e95a9219fa62a542692f134732eL29-R31)