### PR TITLE
fix: program not found redirection 

### DIFF
--- a/apps/backend/src/controller/program/programsController.ts
+++ b/apps/backend/src/controller/program/programsController.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Path, Queries, Res, Route, SuccessResponse, TsoaResponse } from 'tsoa'
 import { OpenAPISafeProgram } from './types'
 import { QuestionnaireData } from '@tee/common'
-import { ErrorJSON, Monitor, ProgramErrorType, ProgramService } from '@tee/backend-ddd'
+import { ErrorJSON, EstablishmentNotFoundError, Monitor, ProgramService } from '@tee/backend-ddd'
+
 @SuccessResponse('200', 'OK')
 @Route('programs')
 export class ProgramsController extends Controller {
@@ -50,10 +51,9 @@ export class ProgramsController extends Controller {
     const program = programService.getOneWithMaybeEligibility(programId, questionnaireData)
 
     if (program.isErr) {
-      if (program.error.message === ProgramErrorType.UnknownId) {
-        Monitor.warning('Unknownn Program id', { programId })
+      if (program.error instanceof EstablishmentNotFoundError) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        return notFoundResponse(404, { message: `Program not found` })
+        return notFoundResponse(404, { message: 'Program not found' })
       }
       Monitor.error('Error in get Program id', { programId })
       this.throwErrorResponse(program.error, requestFailedResponse)

--- a/apps/backend/src/controller/program/programsController.ts
+++ b/apps/backend/src/controller/program/programsController.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Path, Queries, Res, Route, SuccessResponse, TsoaResponse } from 'tsoa'
 import { OpenAPISafeProgram } from './types'
 import { QuestionnaireData } from '@tee/common'
-import { ErrorJSON, Monitor, ProgramService } from '@tee/backend-ddd'
+import { ErrorJSON, Monitor, ProgramErrorType, ProgramService } from '@tee/backend-ddd'
 @SuccessResponse('200', 'OK')
 @Route('programs')
 export class ProgramsController extends Controller {
@@ -42,6 +42,7 @@ export class ProgramsController extends Controller {
   public getOne(
     @Path() programId: string,
     @Queries() questionnaireData: QuestionnaireData,
+    @Res() notFoundResponse: TsoaResponse<404, ErrorJSON>,
     @Res() requestFailedResponse: TsoaResponse<500, ErrorJSON>
   ): OpenAPISafeProgram | void {
     this.setStatus(200)
@@ -49,8 +50,12 @@ export class ProgramsController extends Controller {
     const program = programService.getOneWithMaybeEligibility(programId, questionnaireData)
 
     if (program.isErr) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      Monitor.warning('Error in get Program id', { programId })
+      if (program.error.message === ProgramErrorType.UnknownId) {
+        Monitor.warning('Unknownn Program id', { programId })
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return notFoundResponse(404, { message: `Program not found` })
+      }
+      Monitor.error('Error in get Program id', { programId })
       this.throwErrorResponse(program.error, requestFailedResponse)
       return
     }

--- a/apps/web/src/service/api/requestApi.ts
+++ b/apps/web/src/service/api/requestApi.ts
@@ -25,6 +25,9 @@ export default abstract class RequestApi {
     const url: string = this.query ? `${baseUrl}?${this.query}` : baseUrl
     try {
       const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(JSON.stringify({ statut: response.status, message: response.body }))
+      }
       return Result.ok((await response.json()) as T)
     } catch (error: unknown) {
       return Result.err(error as Error)

--- a/libs/backend-ddd/src/program/application/types.ts
+++ b/libs/backend-ddd/src/program/application/types.ts
@@ -1,3 +1,0 @@
-export enum ProgramErrorType {
-  UnknownId = 'Program Id Inconnu'
-}

--- a/libs/backend-ddd/src/program/application/types.ts
+++ b/libs/backend-ddd/src/program/application/types.ts
@@ -1,0 +1,3 @@
+export enum ProgramErrorType {
+  UnknownId = 'Program Id Inconnu'
+}

--- a/libs/backend-ddd/src/program/domain/programFeatures.ts
+++ b/libs/backend-ddd/src/program/domain/programFeatures.ts
@@ -6,6 +6,7 @@ import { ProgramEligibilityType, ProgramType, ProgramTypeWithEligibility } from 
 import { Objective, QuestionnaireData } from '@tee/common'
 import { Monitor } from '../../common'
 import ProgramCustomizer from './programCustomizer'
+import { ProgramErrorType } from '../application/types'
 
 export default class ProgramFeatures {
   private _programRepository: ProgramRepository
@@ -30,7 +31,7 @@ export default class ProgramFeatures {
     let program = this.getById(id)
     if (!program) {
       Monitor.warning('Requested Program Id unknown', { id })
-      return Result.err(new Error('program Id Inconnu'))
+      return Result.err(new Error(ProgramErrorType.UnknownId))
     }
     if (new ProgramCustomizer().shouldRewritePrograms(questionnaireData)) {
       program = JSON.parse(JSON.stringify(program)) as ProgramType // deep copy before modification

--- a/libs/backend-ddd/src/program/domain/programFeatures.ts
+++ b/libs/backend-ddd/src/program/domain/programFeatures.ts
@@ -6,7 +6,7 @@ import { ProgramEligibilityType, ProgramType, ProgramTypeWithEligibility } from 
 import { Objective, QuestionnaireData } from '@tee/common'
 import { Monitor } from '../../common'
 import ProgramCustomizer from './programCustomizer'
-import { ProgramErrorType } from '../application/types'
+import { ProgramNotFoundError } from './types'
 
 export default class ProgramFeatures {
   private _programRepository: ProgramRepository
@@ -31,7 +31,7 @@ export default class ProgramFeatures {
     let program = this.getById(id)
     if (!program) {
       Monitor.warning('Requested Program Id unknown', { id })
-      return Result.err(new Error(ProgramErrorType.UnknownId))
+      return Result.err(new ProgramNotFoundError())
     }
     if (new ProgramCustomizer().shouldRewritePrograms(questionnaireData)) {
       program = JSON.parse(JSON.stringify(program)) as ProgramType // deep copy before modification

--- a/libs/backend-ddd/src/program/domain/types.ts
+++ b/libs/backend-ddd/src/program/domain/types.ts
@@ -1,0 +1,3 @@
+import CustomError from '../../common/domain/error/customError'
+
+export class ProgramNotFoundError extends CustomError {}

--- a/libs/backend-ddd/src/program/index.ts
+++ b/libs/backend-ddd/src/program/index.ts
@@ -1,2 +1,2 @@
 export * from './application/programService'
-export * from './application/types'
+export * from './domain/types'

--- a/libs/backend-ddd/src/program/index.ts
+++ b/libs/backend-ddd/src/program/index.ts
@@ -1,1 +1,2 @@
 export * from './application/programService'
+export * from './application/types'


### PR DESCRIPTION
Features: 
- sépare les erreurs 404 des erreurs 500 dans le point d'API qui query un unique program
- ajoute un bout de code de gestion d'erreur d'api dans le front end. 

Questions : 
- Archi back OK (création du fichier type dans application) ?
- vérifier que le bout de code du front n'a pas de side effect.  => Veut-on vraiment avec toutes les erreurs catch dans le backend retourner un result.error dans le front. 

lié à #1257 
(Supprime le bug mais ne close pas au vu du message de Coline)