### PR TITLE
fix: sent project form with project id

### DIFF
--- a/apps/web/src/service/api/opportunityApi.ts
+++ b/apps/web/src/service/api/opportunityApi.ts
@@ -9,13 +9,14 @@ import {
   WithoutNullableKeys,
   FormDataType,
   OpportunityType,
-  Opportunity,
+  Opportunity as OpportunityFormType,
   RouteName,
   ProgramData,
   isProjectFormDataType,
   Project
 } from '@/types'
 import RequestApi from '@/service/api/requestApi'
+import Opportunity from '@/utils/opportunity'
 import TrackStructure from '@/utils/track/trackStructure'
 import { ThemeId } from '@tee/data'
 import { router } from '../../router'
@@ -63,7 +64,7 @@ export default class OpportunityApi extends RequestApi {
   }
 
   payload(): OpportunityBody {
-    const opportunity: Opportunity = {
+    const opportunity: OpportunityFormType = {
       type: this._opportunityType,
       id: this._getId(),
       titleMessage: this.getTitleMessage(),
@@ -92,7 +93,7 @@ export default class OpportunityApi extends RequestApi {
   }
 
   private _getId(): string {
-    if (isProjectFormDataType(this._opportunityForm)) {
+    if (Opportunity.isCustomProject(this._opportunityType) && isProjectFormDataType(this._opportunityForm)) {
       return this._opportunityForm.projectTitle.value as string
     }
     return this._id?.toString() as string

--- a/apps/web/src/utils/opportunity.ts
+++ b/apps/web/src/utils/opportunity.ts
@@ -1,4 +1,4 @@
-import { PhoneValidator, EmailValidator, SiretValidator } from '@tee/common'
+import { PhoneValidator, EmailValidator, SiretValidator, OpportunityType } from '@tee/common'
 import { FieldType, RouteName, type ProgramData as ProgramType, Project, FormDataType, ThemeType, ThemeId } from '@/types'
 
 import { useProgramStore } from '@/stores/program'
@@ -121,5 +121,9 @@ export default class Opportunity {
       titreAide: program.titre
     })
     return baseFields
+  }
+
+  static isCustomProject(opportunityType: OpportunityType): boolean {
+    return opportunityType === OpportunityType.CustomProject
   }
 }


### PR DESCRIPTION
Fix afin de passer l'id du projet dans le cas d'un formulaire d'opportunité `project` au lieu du `projetTitle`