### PR TITLE
Feature : ajout du mode cookieless si l'utilisateur n'accepte pas les cookies posthog + envoi de l'opportunityId quand on envoi un formulaire

### DIFF
--- a/apps/web/src/components/element/form/TeeForm.vue
+++ b/apps/web/src/components/element/form/TeeForm.vue
@@ -93,6 +93,8 @@ import { OpportunityType } from '@tee/common'
 import { useNavigationStore } from '@/stores/navigation'
 import Analytics from '@/utils/analytic/analytics'
 import { ProgramType } from '@tee/data'
+import Cookie from '@/utils/cookies'
+import { CookieValue } from '@/types/cookies'
 
 const navigation = useNavigationStore()
 interface Props {
@@ -151,9 +153,13 @@ const saveForm = async () => {
     isLoading.value = true
     const opportunity = new OpportunityApi(localForm.value, props.dataId, props.dataSlug || props.dataId, props.formType)
     requestResponse.value = await opportunity.fetch()
-
     // analytics / send event
-    Analytics.sendEvent(TrackId.Results, getEventName())
+    const posthogCookie = Cookie.getCookieByValue(CookieValue.Posthog)
+    let identification = undefined
+    if (posthogCookie?.accepted) {
+      identification = { opportunityId: requestResponse.value.id }
+    }
+    Analytics.sendEvent(TrackId.Results, getEventName(), identification)
   } finally {
     isLoading.value = false
     formIsSent.value = true

--- a/apps/web/src/components/element/form/TeeForm.vue
+++ b/apps/web/src/components/element/form/TeeForm.vue
@@ -93,8 +93,6 @@ import { OpportunityType } from '@tee/common'
 import { useNavigationStore } from '@/stores/navigation'
 import Analytics from '@/utils/analytic/analytics'
 import { ProgramType } from '@tee/data'
-import Cookie from '@/utils/cookies'
-import { CookieValue } from '@/types/cookies'
 
 const navigation = useNavigationStore()
 interface Props {
@@ -154,12 +152,7 @@ const saveForm = async () => {
     const opportunity = new OpportunityApi(localForm.value, props.dataId, props.dataSlug || props.dataId, props.formType)
     requestResponse.value = await opportunity.fetch()
     // analytics / send event
-    const posthogCookie = Cookie.getCookieByValue(CookieValue.Posthog)
-    let identification = undefined
-    if (posthogCookie?.accepted) {
-      identification = { opportunityId: requestResponse.value.id }
-    }
-    Analytics.sendEvent(TrackId.Results, getEventName(), identification)
+    Analytics.sendEvent(TrackId.Results, getEventName(), { opportunityId: requestResponse.value.id })
   } finally {
     isLoading.value = false
     formIsSent.value = true

--- a/apps/web/src/service/api/opportunityApi.ts
+++ b/apps/web/src/service/api/opportunityApi.ts
@@ -43,6 +43,7 @@ export default class OpportunityApi extends RequestApi {
   async fetch() {
     let resp: ReqResp = {}
     try {
+      const payload: OpportunityBody = this.payload()
       const response = await fetch(this.url, {
         method: 'POST',
         headers: this._headers,
@@ -53,6 +54,9 @@ export default class OpportunityApi extends RequestApi {
       resp.status = response.status
       resp.statusText = response.statusText
       resp.url = response.url
+      if (payload.opportunity.id) {
+        resp.id = payload.opportunity.id
+      }
     } catch (error: unknown) {
       resp.ok = false
       resp.status = 500

--- a/apps/web/src/types/otherTypes.ts
+++ b/apps/web/src/types/otherTypes.ts
@@ -50,6 +50,7 @@ export interface ReqResp extends ReqError {
   code?: string
   message?: string
   data?: any
+  id?: string
   resultsMapping?: ResultsMapping[]
   url?: string
 }

--- a/apps/web/src/utils/analytic/analytics.ts
+++ b/apps/web/src/utils/analytic/analytics.ts
@@ -1,14 +1,9 @@
 import Posthog from '@/utils/analytic/posthog'
-import Cookie from '@/utils/cookies'
-import { CookieValue } from '@/types/cookies'
 import Matomo from './matomo'
 
 export default class Analytics {
-  static sendEvent(action: string, name: string | null = null, value?: string | number | object | Record<string, string | number>) {
-    const posthogCookie = Cookie.getCookieByValue(CookieValue.Posthog)
-    if (posthogCookie?.accepted) {
-      Posthog.captureEvent(action, name ? name : 'unnamed event', value)
-    }
+  static sendEvent(action: string, name: string | null = null, value?: object) {
+    Posthog.captureEvent(name ? name : 'unnamed event', value)
 
     Matomo.sendEvent(action, name, JSON.stringify(value))
   }

--- a/apps/web/src/utils/analytic/analytics.ts
+++ b/apps/web/src/utils/analytic/analytics.ts
@@ -3,6 +3,7 @@ import Matomo from './matomo'
 
 export default class Analytics {
   static sendEvent(action: string, name: string | null = null, value?: object) {
+    console.log(name, value)
     Posthog.captureEvent(name ? name : 'unnamed event', value)
 
     Matomo.sendEvent(action, name, JSON.stringify(value))

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -1,7 +1,5 @@
 import posthog, { PostHog } from 'posthog-js'
 import Config from '@/config'
-import Cookie from '@/utils/cookies'
-import { CookieValue } from '@/types/cookies'
 import { RouteLocationNormalized } from 'vue-router'
 
 export default class Posthog {
@@ -33,10 +31,7 @@ export default class Posthog {
 
   static capturePageView(to: RouteLocationNormalized) {
     if (this._posthog) {
-      const posthogCookie = Cookie.getCookieByValue(CookieValue.Posthog)
-      if (posthogCookie?.accepted) {
-        this._posthog.capture('$pageview', { path: to.fullPath })
-      }
+      this._posthog.capture('$pageview', { path: to.fullPath })
     }
   }
 

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -8,7 +8,7 @@ export default class Posthog {
   private static _posthog?: PostHog
 
   static install() {
-    if (!Config.isProduction()) {
+    if (Config.isProduction()) {
       this._posthog = posthog.init(Config.posthogApiKey, {
         api_host: 'https://eu.i.posthog.com',
         capture_pageview: false,

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -8,11 +8,12 @@ export default class Posthog {
   private static _posthog?: PostHog
 
   static install() {
-    if (Config.isProduction()) {
+    if (!Config.isProduction()) {
       this._posthog = posthog.init(Config.posthogApiKey, {
         api_host: 'https://eu.i.posthog.com',
         capture_pageview: false,
         capture_pageleave: false,
+        persistence: 'memory',
         person_profiles: 'always'
       })
     }
@@ -20,13 +21,13 @@ export default class Posthog {
 
   static activatePosthogCookie() {
     if (this._posthog) {
-      this._posthog.opt_in_capturing()
+      this._posthog.set_config({ persistence: 'localStorage+cookie' })
     }
   }
 
   static deactivatePosthogCookie() {
     if (this._posthog) {
-      this._posthog.opt_out_capturing()
+      this._posthog.set_config({ persistence: 'memory' })
     }
   }
 
@@ -45,9 +46,9 @@ export default class Posthog {
     }
   }
 
-  static captureEvent(action: string, name: string | null = null, value?: string | number | object | Record<string, string | number>) {
+  static captureEvent(name: string | null = null, value?: object) {
     if (this._posthog) {
-      this._posthog.capture(name ? name : 'unnamed event', { action: action, value: value })
+      this._posthog.capture(name ? name : 'unnamed event', value)
     }
   }
 }


### PR DESCRIPTION
- modification de l'api opportunity pour renvoyer l'opportunityId dans la réponse
- initialisation de posthog avec persistence: 'memory' (mode cookieless)
- si acceptation des cookies > persistence: 'localStorage+cookie'
- si refus des cookies > persistence: 'memory'
- plus de vérification de l'acceptation des cookies pour l'envoi des formulaires
- ajout de l'opportunityId dans les properties de la capture de l'event 