### PR TITLE
Fixes : scroll + search siret

### DIFF
--- a/apps/web/src/components/identification/TeeRegisterModal.vue
+++ b/apps/web/src/components/identification/TeeRegisterModal.vue
@@ -50,12 +50,23 @@ import Breakpoint from '@/utils/breakpoints'
 import CompanyDataStorage from '@/utils/storage/companyDataStorage'
 import { onClickOutside } from '@vueuse/core'
 import Navigation from '@/utils/navigation'
+import { useNavigationStore } from '@/stores/navigation'
 
 const registerModal = ref(null)
 const registeredData = CompanyDataStorage.getData()
 const company = ref<CompanyDataType[CompanyDataStorageKey.Company]>(registeredData.value[CompanyDataStorageKey.Company])
 const companySize = ref<CompanyDataType[CompanyDataStorageKey.Size]>(registeredData.value[CompanyDataStorageKey.Size])
 const manualRegistration = ref<boolean>(!!(company.value && !('siret' in company.value)))
+window.addEventListener('popstate', () => {
+  const navigationStore = useNavigationStore()
+  if (navigationStore.hasRegisterModal) {
+    window.scrollTo({
+      top: 0,
+      behavior: 'instant'
+    })
+  }
+})
+
 onClickOutside(registerModal, (ev: MouseEvent) => {
   const target = ev.target as HTMLInputElement
   if (target && !target.classList.contains('ignore-modal-click')) {

--- a/apps/web/src/components/identification/TeeRegisterSiretBar.vue
+++ b/apps/web/src/components/identification/TeeRegisterSiretBar.vue
@@ -20,7 +20,7 @@
       />
       <DsfrButton
         v-if="model"
-        class="search-clear"
+        class="search-clear fr-radius-a--0 fr-bg--white"
         icon="fr-icon-close-line"
         icon-only
         no-outline

--- a/apps/web/src/utils/navigation.ts
+++ b/apps/web/src/utils/navigation.ts
@@ -17,7 +17,7 @@ export default class Navigation {
     if (navigationStore.hasRegisterModal) {
       window.scrollTo({
         top: 0,
-        behavior: 'smooth'
+        behavior: 'instant'
       })
     }
   }


### PR DESCRIPTION
- J'ai aussi un comportement etrange sur le champs SIRET lorsque je cherche mon entreprise et clique rapidement sur Enter. Le menu déroulant disparait et réapparait (ex ici avec le mot "camping". Sinon en attendant un peu il apparait une seule fois (ex avec le mot "hotel"). => on ne reset plus les résultats quand on relance une recherche comme ça on a pas l'effet bizarre de clignotement par contre comme le debounce est plus long qu'un retour de requete (qui du coup peut se faire instantanement avec entrée) on a bien deux requetes qui partent

Ces deux retour la sont fix avec un retour instantané en haut de page si la modale est ouverte
- lorsque je ne suis pas identifié, sur une fiche dispositif ou fiche projet, au clic sur le CTA en bas de page "je complète mon profil", le comportement du scroll au niveau du header est bizarre. il faudrait que le header s'affiche instantanément avec la modale pour éviter ce scroll. 
-D'ailleurs, quand je suis sur la modale et que je navigue avec leretour arrière ou avant du navigateur, il faudrait que le header soit toujours affiché.
