### PR TITLE
fix: Correct typo in French translation

### DIFF
--- a/apps/web/src/translations/fr/program.ts
+++ b/apps/web/src/translations/fr/program.ts
@@ -11,7 +11,7 @@ const programFrDict = {
     CTAButton: 'Contactez un conseiller',
     programType: "Nature de l'aide",
     programEndValidity: "Date de fin de l'aide",
-    programRegisterHighlightText: "Vous souhaitez vérifier automatiquement l'éligibilité de votre entreprise à l'aide de votre siret?",
+    programRegisterHighlightText: "Vous souhaitez vérifier automatiquement l'éligibilité de votre entreprise à l'aide de votre SIRET ?",
     programAvailable: 'Aide disponible',
     programNotAvailable: "Cette aide n'est plus disponible",
     programAvailableUntil: "Disponible jusqu'au {date}",


### PR DESCRIPTION
Corrected the capitalization and punctuation of "SIRET" in the French translation file. This ensures consistency and adherence to proper naming conventions.