### PR TITLE
refactor: Update ChatAdvisorPage to async import iframe-resizer

### DIFF
--- a/apps/web/src/pages/ChatAdvisorPage.vue
+++ b/apps/web/src/pages/ChatAdvisorPage.vue
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 import Contact from '@/utils/contact'
 import type { Directive, DirectiveBinding } from 'vue'
-import { IFrameOptions, iframeResizer } from 'iframe-resizer'
+import { IFrameOptions } from 'iframe-resizer'
 // To make it global see https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/use_with/vue.md#vue3-with-typescript
 
 interface ResizableHTMLElement extends HTMLElement {
@@ -25,9 +25,9 @@ interface ResizableHTMLElement extends HTMLElement {
 }
 
 const vResize: Directive = {
-  mounted(el: HTMLElement, binding: DirectiveBinding) {
-    const options: IFrameOptions = (binding.value as IFrameOptions) || ({} as IFrameOptions)
-
+  async mounted(el: HTMLElement, binding: DirectiveBinding) {
+    const options: IFrameOptions = (binding.value as IFrameOptions) || ({ log: false } as IFrameOptions)
+    const { iframeResizer } = await import('iframe-resizer')
     el.addEventListener('load', () => iframeResizer(options, el))
   },
   unmounted(el: HTMLElement) {


### PR DESCRIPTION
Changed the vResize directive to import 'iframe-resizer' asynchronously inside the mounted hook. This ensures that the iframe resizer library is only loaded when needed, potentially improving page load times. Also updated the default options with log set to false.

closes #1056 