### PR TITLE
Fix : cookieless siret, plus de duplication des personnes

### DIFF
--- a/apps/web/src/components/TeeFooterCookiesButton.vue
+++ b/apps/web/src/components/TeeFooterCookiesButton.vue
@@ -9,13 +9,10 @@
   </li>
 </template>
 <script setup lang="ts">
-import Cookie from '@/utils/cookies'
-
 const openConsent = () => {
   const modal = document.getElementById('fr-consent-modal')
   if (modal) {
     modal.classList.add('fr-modal--opened')
-    Cookie.setCookies()
   }
 }
 </script>

--- a/apps/web/src/components/TeeFooterCookiesButton.vue
+++ b/apps/web/src/components/TeeFooterCookiesButton.vue
@@ -9,10 +9,13 @@
   </li>
 </template>
 <script setup lang="ts">
+import Cookie from '@/utils/cookies'
+
 const openConsent = () => {
   const modal = document.getElementById('fr-consent-modal')
   if (modal) {
     modal.classList.add('fr-modal--opened')
+    Cookie.setCookies()
   }
 }
 </script>

--- a/apps/web/src/components/consent/TeeDsfrConsent.vue
+++ b/apps/web/src/components/consent/TeeDsfrConsent.vue
@@ -43,6 +43,7 @@ const $el = ref<HTMLElement | null>(null)
 
 const onAcceptAll = () => {
   Cookie.acceptAllCookies()
+  closeCustomize()
 }
 const onRefuseAll = () => {
   Cookie.refuseAllCookies()

--- a/apps/web/src/components/consent/TeeDsfrPersonalizeConsent.vue
+++ b/apps/web/src/components/consent/TeeDsfrPersonalizeConsent.vue
@@ -32,7 +32,7 @@
                 >
                   <ConsentElement
                     :cookie="cookie"
-                    @update:model-value="(status) => updateCookieStatus(status, cookie.value)"
+                    @update:model-value="(status: boolean) => updateCookieStatus(status, cookie.value)"
                   />
                 </div>
                 <!-- Bouton de confirmation/fermeture -->
@@ -54,10 +54,10 @@
   </dialog>
 </template>
 <script lang="ts" setup>
-import { Cookies, type CookieValue } from '@/types/cookies'
+import { type CookieValue } from '@/types/cookies'
 import Cookie from '@/utils/cookies'
 
-const cookies = ref<Cookies | undefined>()
+const cookies = Cookie.cookies
 const allStatus = ref<boolean>(false)
 
 const closePersonalize = () => {
@@ -72,10 +72,7 @@ const closeBaseConsent = () => {
     element.classList.add('fr-hidden')
   }
 }
-onMounted(() => {
-  cookies.value = JSON.parse(JSON.stringify(Cookie.cookies.value))
-  console.log(cookies)
-})
+
 const updateCookieStatus = (status: boolean, cookie: CookieValue) => {
   if (cookies.value) {
     cookies.value[cookie].accepted = status
@@ -84,8 +81,7 @@ const updateCookieStatus = (status: boolean, cookie: CookieValue) => {
 }
 
 const saveConsent = () => {
-  const hasChanged = Cookie.hasChanged(cookies.value)
-  if (cookies.value && (hasChanged || !Cookie.areCookiesSet())) {
+  if (cookies.value) {
     Cookie.saveCookies(cookies.value)
   }
   closePersonalize()

--- a/apps/web/src/components/consent/TeeDsfrPersonalizeConsent.vue
+++ b/apps/web/src/components/consent/TeeDsfrPersonalizeConsent.vue
@@ -74,6 +74,7 @@ const closeBaseConsent = () => {
 }
 onMounted(() => {
   cookies.value = JSON.parse(JSON.stringify(Cookie.cookies.value))
+  console.log(cookies)
 })
 const updateCookieStatus = (status: boolean, cookie: CookieValue) => {
   if (cookies.value) {

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -17,15 +17,8 @@ export default class Posthog {
       })
     }
   }
-
   static activatePosthogCookie() {
     this.changePersistance('localStorage+cookie')
-  }
-
-  static resetPosthog() {
-    if (this._posthog) {
-      this._posthog.reset()
-    }
   }
   static changePersistance(state: 'memory' | 'localStorage' | 'cookie' | 'localStorage+cookie' | 'sessionStorage') {
     if (this._posthog) {
@@ -41,19 +34,16 @@ export default class Posthog {
       localStorage.removeItem(`ph_${Config.posthogApiKey}`)
     }
   }
-
   static capturePageView(to: RouteLocationNormalized) {
     if (this._posthog) {
       this._posthog.capture('$pageview', { path: to.fullPath })
     }
   }
-
   static capturePageLeave(from: RouteLocationNormalized) {
     if (this._posthog) {
       this._posthog.capture('$pageleave', { $current_url: window.location.host + from.fullPath, path: from.fullPath })
     }
   }
-
   static captureEvent(name: string | null = null, value?: object) {
     if (this._posthog) {
       this._posthog.capture(name ? name : 'unnamed event', value)

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -19,15 +19,26 @@ export default class Posthog {
   }
 
   static activatePosthogCookie() {
-    if (this._posthog) {
-      this._posthog.set_config({ persistence: 'localStorage+cookie' })
-    }
+    this.changePersistance('localStorage+cookie')
   }
 
-  static deactivatePosthogCookie() {
+  static resetPosthog() {
     if (this._posthog) {
-      Cookie.removeCookie('ph_', true)
-      this._posthog.set_config({ persistence: 'memory' })
+      this._posthog.reset()
+    }
+  }
+  static changePersistance(state: 'memory' | 'localStorage' | 'cookie' | 'localStorage+cookie' | 'sessionStorage') {
+    if (this._posthog) {
+      const distinctId = this._posthog.get_distinct_id()
+      this._posthog.set_config({ persistence: state })
+      this._posthog.identify(distinctId)
+    }
+  }
+  static deactivatePosthogCookie() {
+    if (Cookie.areCookiesSet()) {
+      this.changePersistance('memory')
+      Cookie.removeCookie(`ph_${Config.posthogApiKey}`, false)
+      localStorage.removeItem(`ph_${Config.posthogApiKey}`)
     }
   }
 

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -7,20 +7,24 @@ export default class Posthog {
   private static _posthog?: PostHog
 
   static install() {
-    if (Config.isProduction()) {
-      this._posthog = posthog.init(Config.posthogApiKey, {
-        api_host: 'https://eu.i.posthog.com',
-        capture_pageview: false,
-        capture_pageleave: false,
-        persistence: 'memory',
-        person_profiles: 'always'
-      })
-    }
+    this._posthog = posthog.init(Config.posthogApiKey, {
+      api_host: 'https://eu.i.posthog.com',
+      capture_pageview: false,
+      capture_pageleave: false,
+      persistence: 'memory',
+      person_profiles: 'always'
+    })
   }
 
   static activatePosthogCookie() {
     if (this._posthog) {
       this._posthog.set_config({ persistence: 'localStorage+cookie' })
+    }
+  }
+
+  static resetPosthog() {
+    if (this._posthog) {
+      this._posthog.reset()
     }
   }
 

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -7,24 +7,20 @@ export default class Posthog {
   private static _posthog?: PostHog
 
   static install() {
-    this._posthog = posthog.init(Config.posthogApiKey, {
-      api_host: 'https://eu.i.posthog.com',
-      capture_pageview: false,
-      capture_pageleave: false,
-      persistence: 'memory',
-      person_profiles: 'always'
-    })
+    if (Config.isProduction()) {
+      this._posthog = posthog.init(Config.posthogApiKey, {
+        api_host: 'https://eu.i.posthog.com',
+        capture_pageview: false,
+        capture_pageleave: false,
+        persistence: 'memory',
+        person_profiles: 'always'
+      })
+    }
   }
 
   static activatePosthogCookie() {
     if (this._posthog) {
       this._posthog.set_config({ persistence: 'localStorage+cookie' })
-    }
-  }
-
-  static resetPosthog() {
-    if (this._posthog) {
-      this._posthog.reset()
     }
   }
 

--- a/apps/web/src/utils/analytic/posthog.ts
+++ b/apps/web/src/utils/analytic/posthog.ts
@@ -1,10 +1,12 @@
-import posthog, { PostHog } from 'posthog-js'
+import { CookieValue } from '@/types/cookies'
+import posthog, { PostHog, PostHogConfig } from 'posthog-js'
 import Config from '@/config'
 import { RouteLocationNormalized } from 'vue-router'
 import Cookie from '../cookies'
 
 export default class Posthog {
   private static _posthog?: PostHog
+  private static _cookieName = `ph_${Config.posthogApiKey}`
 
   static install() {
     if (Config.isProduction()) {
@@ -12,7 +14,7 @@ export default class Posthog {
         api_host: 'https://eu.i.posthog.com',
         capture_pageview: false,
         capture_pageleave: false,
-        persistence: 'memory',
+        persistence: Cookie.getCookieStatus(CookieValue.Posthog) ? 'localStorage+cookie' : 'memory',
         person_profiles: 'always'
       })
     }
@@ -20,30 +22,35 @@ export default class Posthog {
   static activatePosthogCookie() {
     this.changePersistance('localStorage+cookie')
   }
-  static changePersistance(state: 'memory' | 'localStorage' | 'cookie' | 'localStorage+cookie' | 'sessionStorage') {
+
+  static changePersistance(state: PostHogConfig['persistence']) {
     if (this._posthog) {
       const distinctId = this._posthog.get_distinct_id()
       this._posthog.set_config({ persistence: state })
       this._posthog.identify(distinctId)
     }
   }
+
   static deactivatePosthogCookie() {
     if (Cookie.areCookiesSet()) {
       this.changePersistance('memory')
-      Cookie.removeCookie(`ph_${Config.posthogApiKey}`, false)
-      localStorage.removeItem(`ph_${Config.posthogApiKey}`)
+      Cookie.removeCookie(this._cookieName, false)
+      localStorage.removeItem(this._cookieName)
     }
   }
+
   static capturePageView(to: RouteLocationNormalized) {
     if (this._posthog) {
       this._posthog.capture('$pageview', { path: to.fullPath })
     }
   }
+
   static capturePageLeave(from: RouteLocationNormalized) {
     if (this._posthog) {
       this._posthog.capture('$pageleave', { $current_url: window.location.host + from.fullPath, path: from.fullPath })
     }
   }
+
   static captureEvent(name: string | null = null, value?: object) {
     if (this._posthog) {
       this._posthog.capture(name ? name : 'unnamed event', value)

--- a/apps/web/src/utils/cookies.ts
+++ b/apps/web/src/utils/cookies.ts
@@ -26,7 +26,7 @@ export default class Cookie {
     }
   }
 
-  static getCookie(key: string): boolean {
+  static getCookieStatus(key: string): boolean {
     const cookies = document.cookie
     const cookiesArray = cookies.split('; ')
 
@@ -41,9 +41,7 @@ export default class Cookie {
   static getCookies(): Cookies {
     const cookiesStatus = document.cookie.split(';').reduce<Record<string, boolean>>((acc, cookie) => {
       const [key, value] = cookie.trim().split('=')
-      if (key && value) {
-        acc[key] = value === 'true'
-      }
+      acc[key] = value === 'true'
       return acc
     }, {})
     return {
@@ -57,7 +55,7 @@ export default class Cookie {
     }
   }
   static hasCookieChanged(cookie: CookieManager): boolean {
-    return !this.areCookiesSet() || this.getCookie(cookie.value) !== cookie.accepted
+    return !this.areCookiesSet() || this.getCookieStatus(cookie.value) !== cookie.accepted
   }
   static saveCookies(newCookies: Cookies) {
     if (Cookie.cookies.value) {
@@ -73,6 +71,7 @@ export default class Cookie {
       })
       document.cookie = 'tee-accept-cookies=true; path=/'
     }
+    this.setCookies()
   }
 
   static acceptAllCookies() {

--- a/apps/web/src/utils/cookies.ts
+++ b/apps/web/src/utils/cookies.ts
@@ -66,7 +66,6 @@ export default class Cookie {
         }
       })
       document.cookie = 'tee-accept-cookies=true; path=/'
-      window.location.reload()
     }
   }
 

--- a/apps/web/src/utils/cookies.ts
+++ b/apps/web/src/utils/cookies.ts
@@ -57,6 +57,7 @@ export default class Cookie {
   static hasCookieChanged(cookie: CookieManager): boolean {
     return !this.areCookiesSet() || this.getCookieStatus(cookie.value) !== cookie.accepted
   }
+
   static saveCookies(newCookies: Cookies) {
     if (Cookie.cookies.value) {
       Object.values(newCookies).forEach((cookie: CookieManager) => {
@@ -107,6 +108,7 @@ export default class Cookie {
       Cookie.saveCookies(Cookie.cookies.value)
     }
   }
+
   static refuseCookie(cookieValue: CookieValue) {
     if (Cookie.cookies.value) {
       Cookie.cookies.value[cookieValue].accepted = false
@@ -122,6 +124,7 @@ export default class Cookie {
       }
     })
   }
+
   static areCookiesSet() {
     const match = document.cookie.match(new RegExp('(^| )tee-accept-cookies=([^;]+)'))
     const cookieValue = match && match[2]


### PR DESCRIPTION
- on ne refresh plus la page quand on change les cookies
- avant de changer le type de persistence, on récupère l'id posthog pour le remettre et éviter la duplication
- on ne change pas le type de persistence si initialement on refuse les cookies (pas de changement de persistence comme posthog et initialisé avec memory) 

Tests effectués en local >> l'id ne change pas dans les event sur le dashboard de posthog
