### PR TITLE
Improve stat page content and reactivity

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,17 @@
+name: Visit StatPage 4 Times Daily to improve loading times
+
+on:
+  schedule:
+    - cron: "25 1 * * *"
+    - cron: "25 7 * * *"
+    - cron: "25 13 * * *"
+    - cron: "25 19 * * *"
+
+jobs:
+  visit-webpage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Visit the webpage
+        run: |
+          curl -s -o /dev/null https://mission-transition-ecologique.beta.gouv.fr/stats

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -146,6 +146,9 @@ const getBrevoCreationDates = async (): Promise<Result<Date[], Error>> => {
     }
     const dateList: Date[] = []
     for (const deal of brevoDealResponse.items) {
+      if (deal.attributes.pipeline != Config.BREVO_DEAL_PIPELINE) {
+        continue
+      }
       const dealDate: Date = new Date(deal.attributes.created_at)
       dateList.push(dealDate)
     }


### PR DESCRIPTION
- ajout d'un filtre pour ne calculer que les stats de la pipeline de prod
- ajout d'un github workflow pour visiter la page stat 4 fois par jour pour que, grâce au cache de 24h, la page soit en cache la grande majorité du temps. 