### PR TITLE
fix:  "see other criteria" button

### DIFF
--- a/apps/web/src/components/program/detail/ProgramDetail.vue
+++ b/apps/web/src/components/program/detail/ProgramDetail.vue
@@ -189,6 +189,7 @@
         </div>
         <ProgramAccordion
           v-if="program && program['conditions d\'éligibilité']"
+          id="eligibilite"
           :accordion-id="`${program.id}-eligibility`"
           :title="Translation.t('program.programAmIEligible')"
         >

--- a/apps/web/src/components/program/detail/ProgramEligibilityBar.vue
+++ b/apps/web/src/components/program/detail/ProgramEligibilityBar.vue
@@ -45,7 +45,7 @@ const getEligibilityLink: ComputedRef<TeeEligibilityBarLink | undefined> = compu
   switch (program.value?.eligibility) {
     case ProgramEligibilityType.PartiallyEligible:
       return {
-        hash: 'program-details-accordion-group',
+        hash: 'eligibilite',
         label: 'Voir les autres critères à respecter',
         labelMobile: 'Vérifier les critères'
       }


### PR DESCRIPTION
Sur  
https://mission-transition-ecologique.beta.gouv.fr/aides-entreprise/diag-ecoconception?siret=83014132100034&effectif=TPE

Le premier CTA : [Voir les autres critères à respecter]; ne fait rien. 

Je pense que c'est la maj du dsfr qui est à l'origine de la regression. 
Je ne suis pas certain du comportement précédent d'où les reviews.
C'est plutôt prioritaire donc n'hésitez pas à faire els modifs vous même / à envoyer en prod si vous êtes le 2ème reviewer ! 

Note : j'ai mis un hash en francais car c'est visible par l'utilisateur lorsqu'il hover sur le bouton. 

