### PR TITLE
fix: Mise à jour de la gestion des chemins compatible esNext et commonjs

### DIFF
--- a/libs/data/src/common/baserow/abstractBaserow.ts
+++ b/libs/data/src/common/baserow/abstractBaserow.ts
@@ -1,13 +1,11 @@
 import axios from 'axios'
 import dotenv from 'dotenv'
-import path from 'path'
-import { fileURLToPath } from 'url'
 import { Id, LinkObject } from './types'
 
 dotenv.config()
 
 export abstract class AbstractBaserow {
-  protected readonly __dirname = path.dirname(fileURLToPath(import.meta.url))
+  protected readonly __dirname = process.cwd()
   private readonly _apiToken = this._setBaserowToken()
   private readonly _baseUrl = 'https://api.baserow.io/api'
   protected readonly _themeTableId = 305258

--- a/libs/data/src/common/baserow/projectBaserow.ts
+++ b/libs/data/src/common/baserow/projectBaserow.ts
@@ -10,7 +10,7 @@ import { LogLevel } from '../logger/types'
 export class ProjectBaserow extends AbstractBaserow {
   private readonly _projectTableId = 305253
   private readonly _imagePath = '/images/projet/'
-  private readonly _logPath: string = path.join(this.__dirname, '../../../static/project_images_download_info.json')
+  private readonly _logPath: string = path.join(this.__dirname, './static/project_images_download_info.json')
   private _imageDownloader: ImageBaserow
   private readonly _defaultProjectImageName = 'plan-transition-bas-carbone.webp'
 

--- a/libs/data/src/dataPipeline.ts
+++ b/libs/data/src/dataPipeline.ts
@@ -2,16 +2,15 @@ import * as dotenv from 'dotenv'
 import path from 'path'
 import * as fs from 'fs'
 import * as yaml from 'js-yaml'
-import { fileURLToPath } from 'url'
 import { ProgramType, ProgramWithoutId } from './program/program'
 import { FileManager } from './common/fileManager'
 
 dotenv.config()
 
-const OUTPUT_FOLDER_PATH = '../generated'
+const OUTPUT_FOLDER_PATH = './generated'
 const OUTPUT_FILENAME = 'dataset_out.json'
-const PROGRAMS_FOLDER_PATH = '../programs'
-const INTERFACE_PATH = './../common/interface.yaml'
+const PROGRAMS_FOLDER_PATH = './programs'
+const INTERFACE_PATH = './common/interface.yaml'
 
 /**
  * Build programs dataset from folder and yaml files
@@ -24,7 +23,7 @@ const INTERFACE_PATH = './../common/interface.yaml'
  */
 export const readPrograms = (log = false): ProgramType[] => {
   const programs: ProgramType[] = []
-  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const __dirname = process.cwd()
   // joining path of directory
   const dataDirPath: string = path.join(__dirname, PROGRAMS_FOLDER_PATH)
 
@@ -50,7 +49,7 @@ export const readPrograms = (log = false): ProgramType[] => {
  * "packages/data/common/interface.yaml")
  */
 export const prependInterface = (programs: ProgramType[], log = false): ProgramType[] => {
-  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const __dirname = process.cwd()
   const fullPath: string = path.join(__dirname, INTERFACE_PATH)
 
   if (log) console.log('🗎 reading constants at', fullPath)
@@ -70,7 +69,7 @@ export const prependInterface = (programs: ProgramType[], log = false): ProgramT
  */
 export const buildProgramJson = (programs: ProgramType[]): void => {
   console.log('♺ Converting data to JSON')
-  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const __dirname = process.cwd()
   const dataAsJson: string = JSON.stringify(programs, null, 2)
 
   const dataBuiltOutputDir: string = path.join(__dirname, OUTPUT_FOLDER_PATH)

--- a/libs/data/src/generateProgramType.ts
+++ b/libs/data/src/generateProgramType.ts
@@ -3,7 +3,6 @@ import fs from 'fs'
 import { compileFromFile } from 'json-schema-to-typescript'
 import path from 'path'
 import { FileManager } from './common/fileManager'
-import { fileURLToPath } from 'url'
 
 /** generates a .d.ts typescript type for a Program object, from its
  * json-schema specification
@@ -11,12 +10,10 @@ import { fileURLToPath } from 'url'
 const generateProgramType = (): void => {
   console.log('💥 generating typescript Program type from the json schema specification.\n')
 
-  const DEFAULT_SCHEMA_PATH = '../schemas/program-with-publicodes-schema.json'
+  const DEFAULT_SCHEMA_PATH = './schemas/program-with-publicodes-schema.json'
   const relativeSchemaPath: string = process.env['SCHEMA_PATH'] || DEFAULT_SCHEMA_PATH
-  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const __dirname = process.cwd()
   const schemaPath: string = path.join(__dirname, relativeSchemaPath)
-
-  console.log('Reading json schema at', schemaPath)
 
   const generatedTypeDir = path.join('src', 'generated')
   FileManager.createFolderIfNotExists(generatedTypeDir)

--- a/libs/data/src/operators/operatorFeatures.ts
+++ b/libs/data/src/operators/operatorFeatures.ts
@@ -1,15 +1,14 @@
 import path from 'path'
 import fs from 'fs'
-import { fileURLToPath } from 'url'
 import { OperatorBaserow } from '../common/baserow/operatorBaserow'
 import { RawOperator } from './types/domain'
 import { FileManager } from '../common/fileManager'
 
 export class OperatorFeatures {
-  private readonly __dirname = path.dirname(fileURLToPath(import.meta.url))
-  private readonly _outputFilePath: string = path.join(this.__dirname, '../../static/operators.json')
-  private readonly _outputTypeFilePath: string = path.join(this.__dirname, './types/generatedShared.ts')
-  private readonly _schemaFilePath = path.join(this.__dirname, '../../schemas/program-with-publicodes-schema.json')
+  private readonly __dirname = process.cwd()
+  private readonly _outputFilePath: string = path.join(this.__dirname, './static/operators.json')
+  private readonly _outputTypeFilePath: string = path.join(this.__dirname, './src/operators/types/generatedShared.ts')
+  private readonly _schemaFilePath = path.join(this.__dirname, './schemas/program-with-publicodes-schema.json')
   async updateOperatorsData() {
     const operators = await new OperatorBaserow().getAll()
     FileManager.writeJson(this._outputFilePath, operators, 'operator.json updated')

--- a/libs/data/src/program/yamlGenerator/programYamlsGenerator.ts
+++ b/libs/data/src/program/yamlGenerator/programYamlsGenerator.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import fs from 'fs'
 import * as yaml from 'js-yaml'
-import { fileURLToPath } from 'url'
 import { DataProgram, Status } from '../types/domain'
 import { ProgramBaserow } from '../../common/baserow/programBaserow'
 import { Logger } from '../../common/logger/logger'
@@ -9,7 +8,7 @@ import { CoreGenerator } from './coreGenerator'
 import { LoggerType } from '../../common/logger/types'
 
 export class ProgramYamlsGenerator {
-  private readonly __dirname = path.dirname(fileURLToPath(import.meta.url))
+  private readonly __dirname = process.cwd()
   outputDirectory: string = path.join(this.__dirname, '../../programs/')
   private _logger: Logger
 

--- a/libs/data/src/project/projectFeatures.ts
+++ b/libs/data/src/project/projectFeatures.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import { fileURLToPath } from 'url'
 import { ProjectBaserow } from '../common/baserow/projectBaserow'
 import { DataProject } from './types/domain'
 import { jsonPrograms } from '../../generated/index'
@@ -12,9 +11,9 @@ import { LoggerType, LogLevel } from '../common/logger/types'
 import { FileManager } from '../common/fileManager'
 
 export class ProjectFeatures {
-  private readonly __dirname = path.dirname(fileURLToPath(import.meta.url))
-  private readonly _outputFilePath: string = path.join(this.__dirname, '../../static/projects.json')
-  private readonly _outputImageDirectory: string = path.join(this.__dirname, '../../../../apps/web/public/images/projet')
+  private readonly __dirname = process.cwd()
+  private readonly _outputFilePath: string = path.join(this.__dirname, './static/projects.json')
+  private readonly _outputImageDirectory: string = path.join(this.__dirname, '../../apps/nuxt/src/public/images/projet')
   private _programs: ProgramType[] = []
   private _logger: Logger
 


### PR DESCRIPTION
### Mise à jour de la gestion des chemins compatible esNext et commonjs
Remplacement de l'utilisation de `fileURLToPath` et `path.dirname` par `process.cwd()` pour permettre l'utilisation avec esNext et Commonjs

#### Défaut / effet de bord
Les chemins relatifs ont être mis à jours car `process.cwd()` retourne le dossier courant d'execution (de là où l'on execute le process)