### PR TITLE
Chore/update sirene api

### DIFF
--- a/apps/nuxt/.env.dist
+++ b/apps/nuxt/.env.dist
@@ -40,7 +40,7 @@ BPI_API_ENABLED=false
 
 ###> SIRENE/SIRET ###
 # API token for "API Sirene V3 by insee"
-# https://api.insee.fr/catalogue/site/themes/wso2/subthemes/insee/pages/item-info.jag?name=Sirene&version=V3&provider=insee
+# https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f?aq=ALL
 SIRENE_API_TOKEN=xxxxxx
 ###< SIRENE/SIRET ###
 

--- a/apps/nuxt/.env.dist
+++ b/apps/nuxt/.env.dist
@@ -41,7 +41,7 @@ BPI_API_ENABLED=false
 ###> SIRENE/SIRET ###
 # API token for "API Sirene V3 by insee"
 # https://portail-api.insee.fr/catalog/api/2ba0e549-5587-3ef1-9082-99cd865de66f?aq=ALL
-SIRENE_API_TOKEN=xxxxxx
+SIRENE_API_311_TOKEN=xxxxxx
 ###< SIRENE/SIRET ###
 
 ###> BREVO ###

--- a/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
@@ -12,7 +12,7 @@ import Monitor from '../../../../common/domain/monitoring/monitor'
  * variable and get an Établissement by its siret from the Sirene API
  */
 export const getEstablishment: EstablishmentRepository['get'] = async (siret) => {
-  const token = process.env['SIRENE_API_TOKEN'] || ''
+  const token = process.env['SIRENE_API_311_TOKEN'] || ''
   return requestSireneAPI(token, siret)
 }
 

--- a/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
@@ -75,6 +75,6 @@ const parseEstablishment = (establishmentDocument: EstablishmentDocument): Estab
 const makeHeaders = (token: string) => {
   return {
     ...AxiosHeaders.makeJsonHeader(),
-    ...AxiosHeaders.makeBearerHeader(token)
+    ...{ 'X-INSEE-Api-Key-Integration': token }
   }
 }

--- a/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
@@ -23,7 +23,7 @@ export const getEstablishment: EstablishmentRepository['get'] = async (siret) =>
  * @arg siret - siret number of the company to fetch
  */
 export const requestSireneAPI = async (token: string, siret: string): Promise<Result<EstablishmentDetails, Error>> => {
-  const api_sirene_url = `https://api.insee.fr/entreprises/sirene/V3.11/siret/${siret}`
+  const api_sirene_url = `https://api.insee.fr/api-sirene/3.11/siret/${siret}`
 
   try {
     const response: AxiosResponse<EstablishmentDocument> = await axios.get(api_sirene_url, {


### PR DESCRIPTION
Mise à jour de l'API siren.

Le token est disponible sur le compte portail insee (acccès sur vaultwarden). 
API testable sur https://tee-preprod-pr1493.osc-fr1.scalingo.io/ en rentrant un SIRET dans le champs de recherche entreprise de la modale

close #1361