### PR TITLE
hotfix: sitemap

### DIFF
--- a/apps/nuxt/src/server/api/__sitemap__/projects.ts
+++ b/apps/nuxt/src/server/api/__sitemap__/projects.ts
@@ -1,13 +1,12 @@
 import { SitemapUrlInput } from '#sitemap/types'
 import { RoutePath } from '@/types'
+import { ProjectService } from '@tee/backend-ddd'
 import { UrlBuilder } from '~/server/utils/UrlBuilder'
-import ProjectApi from '~/tools/api/projectApi'
 import { ChangeFreq, Priority } from '~/types/sitemapType'
 
 export default defineSitemapEventHandler(async () => {
   const urls: SitemapUrlInput[] = []
-
-  const projects = await new ProjectApi().get()
+  const projects = new ProjectService().getFiltered({})
   if (projects.isOk) {
     for (const project of projects.value) {
       const url = UrlBuilder.params(RoutePath.CatalogProjectDetail, { projectSlug: project.slug })


### PR DESCRIPTION
Remplacement de ProjectApi par ProjectService pour récupérer les projets. Isolation du backend par utilisation d'un service du ddd