### PR TITLE
feat: improve backend program not found error monitoring

### DIFF
--- a/apps/nuxt/src/server/api/programs/[programId].get.ts
+++ b/apps/nuxt/src/server/api/programs/[programId].get.ts
@@ -29,7 +29,7 @@ const programCached = cachedFunction(
 
       throw createError({
         statusCode: 500,
-        statusMessage: 'Server internal error in get Program id'
+        statusMessage: 'Server internal error in get Program by id'
       })
     }
 

--- a/apps/nuxt/src/server/api/programs/[programId].get.ts
+++ b/apps/nuxt/src/server/api/programs/[programId].get.ts
@@ -1,6 +1,6 @@
 import { QuestionnaireData, serverQuestionnaireDataSchema } from '@tee/common'
 import { defineEventHandler, H3Event } from 'h3'
-import { EstablishmentNotFoundError, Monitor, ProgramService } from '@tee/backend-ddd'
+import { ProgramNotFoundError, ProgramService } from '@tee/backend-ddd'
 import { z } from 'zod'
 
 const programIdSchema = z.object({
@@ -20,17 +20,16 @@ const programCached = cachedFunction(
     const program = programService.getOneWithMaybeEligibility(programId, questionnaireData)
 
     if (program.isErr) {
-      if (program.error instanceof EstablishmentNotFoundError) {
+      if (program.error instanceof ProgramNotFoundError) {
         throw createError({
           statusCode: 404,
           statusMessage: 'Program not found'
         })
       }
 
-      Monitor.error('Error in get Program id', { programId })
       throw createError({
         statusCode: 500,
-        statusMessage: 'Server internal error'
+        statusMessage: 'Server internal error in get Program id'
       })
     }
 

--- a/libs/backend-ddd/src/program/domain/programFeatures.ts
+++ b/libs/backend-ddd/src/program/domain/programFeatures.ts
@@ -4,7 +4,6 @@ import { sortPrograms } from './sortPrograms'
 import { Result } from 'true-myth'
 import { ProgramEligibilityType, ProgramType, ProgramTypeWithEligibility } from '@tee/data'
 import { Objective, QuestionnaireData } from '@tee/common'
-import { Monitor } from '../../common'
 import ProgramCustomizer from './programCustomizer'
 import { ProgramNotFoundError } from './types'
 
@@ -30,7 +29,6 @@ export default class ProgramFeatures {
   public getOneWithMaybeEligibility(id: string, questionnaireData: QuestionnaireData): Result<ProgramTypeWithEligibility, Error> {
     let program = this.getById(id)
     if (!program) {
-      Monitor.warning('Requested Program Id unknown', { id })
       return Result.err(new ProgramNotFoundError())
     }
     if (new ProgramCustomizer().shouldRewritePrograms(questionnaireData)) {

--- a/libs/backend-ddd/src/program/domain/programFeatures.ts
+++ b/libs/backend-ddd/src/program/domain/programFeatures.ts
@@ -4,6 +4,7 @@ import { sortPrograms } from './sortPrograms'
 import { Result } from 'true-myth'
 import { ProgramEligibilityType, ProgramType, ProgramTypeWithEligibility } from '@tee/data'
 import { Objective, QuestionnaireData } from '@tee/common'
+import { Monitor } from '../../common'
 import ProgramCustomizer from './programCustomizer'
 import { ProgramNotFoundError } from './types'
 
@@ -29,6 +30,7 @@ export default class ProgramFeatures {
   public getOneWithMaybeEligibility(id: string, questionnaireData: QuestionnaireData): Result<ProgramTypeWithEligibility, Error> {
     let program = this.getById(id)
     if (!program) {
+      Monitor.warning('Requested Program Id unknown', { id })
       return Result.err(new ProgramNotFoundError())
     }
     if (new ProgramCustomizer().shouldRewritePrograms(questionnaireData)) {


### PR DESCRIPTION
- fix a EstablishementNotFound into ProgramNotFound

Je confirme que `createError` transmet l'erreur à sentry avec une 500 mais pas avec une 404. 

(J'ai testé en créant une 404 et en commentant le bloc qui change le comportement pour les 404. Il y a création d'un erreur avec le message d'erreur custom qui montre que c'est bien le create error qui créé l'erreur. 
Au contraire, en remettant le bloc spécifique 404, il n'y a plus de création d'erreur automatique. )