### PR TITLE
hotfix: no program found with null denominations (also fixing playwright error notifications)

### DIFF
--- a/apps/nuxt/src/components/identification/details/TeeProfileDetails.vue
+++ b/apps/nuxt/src/components/identification/details/TeeProfileDetails.vue
@@ -60,7 +60,7 @@ const profile = ref<RegisterDetails>({
     icon: 'fr-icon-account-pin-circle-line',
     value: props.company && 'siret' in props.company ? props.company.siret : undefined,
     type: RegisterDetailType.Siret,
-    tagLabel: props.company?.denomination
+    tagLabel: props.company?.denomination || 'Entreprise'
   },
   localisation: {
     title: 'Localisation',

--- a/apps/nuxt/src/tools/companyData/companyData.ts
+++ b/apps/nuxt/src/tools/companyData/companyData.ts
@@ -51,7 +51,8 @@ export class CompanyData {
       ...company,
       structure_size: profileData.size.value,
       ...profileData.localisation.value,
-      ...profileData.activity.value
+      ...profileData.activity.value,
+      denomination: company?.denomination || `Entreprise : ${profileData.activity.value} - ${profileData.localisation.value?.region}`
     } as CompanyDataType[CompanyDataStorageKey.Company]
   }
 

--- a/apps/nuxt/src/tools/companyData/companyData.ts
+++ b/apps/nuxt/src/tools/companyData/companyData.ts
@@ -52,7 +52,8 @@ export class CompanyData {
       structure_size: profileData.size.value,
       ...profileData.localisation.value,
       ...profileData.activity.value,
-      denomination: company?.denomination || `Entreprise : ${profileData.activity.value} - ${profileData.localisation.value?.region}`
+      denomination:
+        company?.denomination || `Entreprise : ${profileData.activity.value?.secteur} - ${profileData.localisation.value?.region}`
     } as CompanyDataType[CompanyDataStorageKey.Company]
   }
 

--- a/apps/nuxt/src/tools/companyData/companyData.ts
+++ b/apps/nuxt/src/tools/companyData/companyData.ts
@@ -37,9 +37,8 @@ export class CompanyData {
 
   static patchCompanyData(company: CompanyDataRegisterType, profileData?: RegisterDetails) {
     const denomination =
-      company?.denomination !== ''
-        ? company?.denomination
-        : `Entreprise : ${profileData?.activity?.value?.secteur || company.secteur} - ${profileData?.localisation?.value?.region || company.region}`
+      company?.denomination ||
+      `Entreprise : ${profileData?.activity?.value?.secteur || company?.secteur} - ${profileData?.localisation?.value?.region || company?.region}`
     return {
       ...company,
       denomination

--- a/libs/backend-ddd/src/establishment/domain/establishmentFeatures.ts
+++ b/libs/backend-ddd/src/establishment/domain/establishmentFeatures.ts
@@ -87,16 +87,13 @@ export default class EstablishmentFeatures {
       codeNAF: establishment.nafCode,
       codeNAF1: establishment.nafSectionCode || '',
       ville: establishment.address.cityLabel,
+      denomination: establishment.denomination || '',
       codePostal: establishment.address.zipCode,
       region: establishment.region || '',
       legalCategory: establishment.legalCategory,
       structure_size: this._computeBestStructureSizeGuess(establishment),
       secteur: establishment.nafLabel || '',
       creationDate: establishment.creationDate
-    }
-
-    if (establishment?.denomination) {
-      result.denomination = establishment.denomination
     }
 
     return result

--- a/libs/backend-ddd/src/establishment/domain/establishmentFeatures.ts
+++ b/libs/backend-ddd/src/establishment/domain/establishmentFeatures.ts
@@ -82,7 +82,7 @@ export default class EstablishmentFeatures {
   }
 
   private _convertEstablishmentToFront(establishment: Establishment): EstablishmentFront {
-    return {
+    const result: EstablishmentFront = {
       siret: establishment.siret,
       codeNAF: establishment.nafCode,
       codeNAF1: establishment.nafSectionCode || '',
@@ -91,10 +91,15 @@ export default class EstablishmentFeatures {
       region: establishment.region || '',
       legalCategory: establishment.legalCategory,
       structure_size: this._computeBestStructureSizeGuess(establishment),
-      denomination: establishment.denomination,
       secteur: establishment.nafLabel || '',
       creationDate: establishment.creationDate
     }
+
+    if (establishment?.denomination) {
+      result.denomination = establishment.denomination
+    }
+
+    return result
   }
 
   private _convertEstablishmentToSearch(establishment: Establishment): EstablishmentSearch {

--- a/libs/backend-ddd/src/establishment/domain/types.ts
+++ b/libs/backend-ddd/src/establishment/domain/types.ts
@@ -8,7 +8,7 @@ export interface EstablishmentDetails {
   nic: string
   siret: string
   creationDate: string
-  denomination: string
+  denomination?: string
   legalCategory: string
   nafCode: string
   address: {

--- a/libs/backend-ddd/src/establishment/domain/types.ts
+++ b/libs/backend-ddd/src/establishment/domain/types.ts
@@ -8,7 +8,7 @@ export interface EstablishmentDetails {
   nic: string
   siret: string
   creationDate: string
-  denomination?: string
+  denomination: string
   legalCategory: string
   nafCode: string
   address: {

--- a/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
@@ -51,6 +51,7 @@ const parseEstablishment = (establishmentDocument: EstablishmentDocument): Estab
     siren: rawEstablishment.siren,
     nic: rawEstablishment.nic,
     siret: rawEstablishment.siret,
+    denomination: rawEstablishment.uniteLegale.denominationUniteLegale,
     creationDate: rawEstablishment.uniteLegale.dateCreationUniteLegale,
     nafCode: rawEstablishment.uniteLegale.activitePrincipaleUniteLegale,
     legalCategory: rawEstablishment.uniteLegale.categorieJuridiqueUniteLegale,
@@ -65,9 +66,6 @@ const parseEstablishment = (establishmentDocument: EstablishmentDocument): Estab
     workforceRange: rawEstablishment.trancheEffectifsEtablissement
   }
 
-  if (rawEstablishment.uniteLegale.denominationUniteLegale) {
-    result.denomination = rawEstablishment.uniteLegale.denominationUniteLegale
-  }
   return result
 }
 

--- a/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/sirene/sirene.ts
@@ -47,12 +47,11 @@ export const requestSireneAPI = async (token: string, siret: string): Promise<Re
 
 const parseEstablishment = (establishmentDocument: EstablishmentDocument): EstablishmentDetails => {
   const rawEstablishment = establishmentDocument.etablissement
-  return {
+  const result: EstablishmentDetails = {
     siren: rawEstablishment.siren,
     nic: rawEstablishment.nic,
     siret: rawEstablishment.siret,
     creationDate: rawEstablishment.uniteLegale.dateCreationUniteLegale,
-    denomination: rawEstablishment.uniteLegale.denominationUniteLegale,
     nafCode: rawEstablishment.uniteLegale.activitePrincipaleUniteLegale,
     legalCategory: rawEstablishment.uniteLegale.categorieJuridiqueUniteLegale,
     address: {
@@ -65,6 +64,11 @@ const parseEstablishment = (establishmentDocument: EstablishmentDocument): Estab
     },
     workforceRange: rawEstablishment.trancheEffectifsEtablissement
   }
+
+  if (rawEstablishment.uniteLegale.denominationUniteLegale) {
+    result.denomination = rawEstablishment.uniteLegale.denominationUniteLegale
+  }
+  return result
 }
 
 /**


### PR DESCRIPTION
Les erreurs playwright sont en partie due à l'erreur suivante : 
- lorsque la recherche est effectuée via l'api siren et qu'il n'y a pas de nom, le filtrage n'est plus réalisé , exemple avec cet url : https://mission-transition-ecologique.beta.gouv.fr/questionnaire/resultat?choix-du-parcours=je-ne-sais-pas-par-ou-commencer&locaux=locataire&mobilite=oui&matieres-premieres=oui&tri-dechets=oui&dechets=oui&gestion-eau=oui&energie=oui&audit=non&siret=78893947800020&effectif=EI

Fix proposé : 
- dénomination optionelle dans le back
- set valeurs par défaut pour affichage front s'il n'y a pas de dénomination. 

Amélioration possible: 
- Lorsque l'on va directement sur [l'url au dessus](https://tee-preprod-pr1554.osc-fr1.scalingo.io/questionnaire/resultat?choix-du-parcours=je-ne-sais-pas-par-ou-commencer&locaux=locataire&mobilite=oui&matieres-premieres=oui&tri-dechets=oui&dechets=oui&gestion-eau=oui&energie=oui&audit=non&siret=78893947800020&effectif=EI), l'icone qui montre qu'on est bien enregistré n'affiche aucun nom. Il serait mieux d'afficher le texte ``Entreprise : ${profileData.activity.value} - ${profileData.localisation.value?.region}``  .  Un nom est bien affiché lorsque l'on set la même entreprise via la modale (rechercher "Yohann Valentin" dans la modale pour la set via l'api recherche-entreprise et "78893947800020" pour passer par l'api siren). 
