### PR TITLE
Feat: add project sorting by sector

### DIFF
--- a/apps/nuxt/src/components/catalog/CatalogProjects.vue
+++ b/apps/nuxt/src/components/catalog/CatalogProjects.vue
@@ -53,11 +53,11 @@ import { useCompanyData } from '@/stores/companyData'
 import { useProjectStore } from '@/stores/project'
 import { CompanyData } from '@/tools/companyData'
 import { ProjectManager } from '@/tools/project/projectManager'
+import ProjectSorter from '@/tools/project/projectSorter'
 import { MetaSeo } from '@/tools/metaSeo'
 import { computed } from 'vue'
 import ProjectFilter from '@/tools/project/projectFilter'
 import { Theme } from '@/tools/theme'
-import ProjectSorter from '@/tools/project/projectSorter'
 
 interface Props {
   showTitleBanner?: boolean

--- a/apps/nuxt/src/components/catalog/CatalogProjects.vue
+++ b/apps/nuxt/src/components/catalog/CatalogProjects.vue
@@ -53,11 +53,11 @@ import { useCompanyData } from '@/stores/companyData'
 import { useProjectStore } from '@/stores/project'
 import { CompanyData } from '@/tools/companyData'
 import { ProjectManager } from '@/tools/project/projectManager'
-import ProjectSorter from '@/tools/project/projectSorter'
 import { MetaSeo } from '@/tools/metaSeo'
 import { computed } from 'vue'
 import ProjectFilter from '@/tools/project/projectFilter'
 import { Theme } from '@/tools/theme'
+import ProjectSorter from '@/tools/project/projectSorter'
 
 interface Props {
   showTitleBanner?: boolean
@@ -93,6 +93,12 @@ const theme = Theme.getThemeFromSelectedTheme()
 
 const filteredProjects = ProjectFilter.filter(projects, theme)
 const sortedProjects = ProjectSorter.sort(filteredProjects)
+//   computed(() => {
+//   if (hasFullRegisteredData.value && useFiltersStore().isCompanyDataSelected()) {
+//     return ProjectSorter.bySector(filteredProjects, CompanyData.dataRef.value[CompanyDataStorageKey.Company]?.codeNAF1).value
+//   }
+//   return ProjectSorter.sort(filteredProjects).value
+// })
 
 const countProjects = computed(() => {
   return filteredProjects.value?.length || 0

--- a/apps/nuxt/src/components/project/list/ProjectCard.vue
+++ b/apps/nuxt/src/components/project/list/ProjectCard.vue
@@ -8,10 +8,27 @@
     :link="getRouteToProjectDetail(project)"
     class="teste2e-project-target"
   >
+    <template #start-details>
+      <DsfrBadge
+        :label="project.sectors.length"
+        :no-icon="true"
+        class="fr-badge--success"
+      />
+      <DsfrBadge
+        :label="project.priority"
+        :no-icon="true"
+        class="fr-badge--success"
+      />
+    </template>
     <template
       v-if="isPriorityProject"
       #start-details
     >
+      <DsfrBadge
+        :label="project.sectors.length"
+        :no-icon="true"
+        class="fr-badge--success"
+      />
       <div
         v-if="!isUniquePriority"
         class="fr-card__header--priority fr-hidden fr-unhidden-lg"

--- a/apps/nuxt/src/stores/filters.ts
+++ b/apps/nuxt/src/stores/filters.ts
@@ -24,6 +24,10 @@ export const useFiltersStore = defineStore('filters', () => {
     return filters.value[FilterItemKeys.themeType]
   }
 
+  function isCompanyDataSelected() {
+    return filters.value[FilterItemKeys.companyData]
+  }
+
   function resetFilters() {
     filters.value = {
       [FilterItemKeys.typeAid]: [],
@@ -50,6 +54,7 @@ export const useFiltersStore = defineStore('filters', () => {
     hasThemeTypeSelected,
     getThemeTypeSelected,
     setThemeTypeSelected,
+    isCompanyDataSelected,
     resetFilters,
     resetFilter
   }

--- a/apps/nuxt/src/tools/project/projectFilter.ts
+++ b/apps/nuxt/src/tools/project/projectFilter.ts
@@ -1,14 +1,4 @@
-import {
-  ProgramData,
-  ThemeId,
-  ThemeType,
-  ProjectType,
-  EstablishmentFront,
-  FilterItemKeys,
-  type ValueOf,
-  FiltersType,
-  ProjectEligibility
-} from '@/types'
+import { ThemeId, ThemeType, ProjectType, EstablishmentFront, FilterItemKeys, type ValueOf, FiltersType, ProjectEligibility } from '@/types'
 import { Theme } from '@/tools/theme'
 import { ComputedRef, Ref } from 'vue'
 import { CompanyData } from '@/tools/companyData'
@@ -60,10 +50,6 @@ export default class ProjectFilter {
       return ProjectEligibility.isEligible(project, (CompanyData.company as EstablishmentFront)?.codeNAF1)
     }
     return true
-  }
-
-  static byPrograms(project: ProjectType, filteredPrograms: ProgramData[]) {
-    return project.programs.some((programId) => filteredPrograms.some(({ id }) => id === programId))
   }
 
   static isValidFilterValue(programFilterValue: ValueOf<FiltersType> | undefined) {

--- a/apps/nuxt/src/tools/project/projectSorter.ts
+++ b/apps/nuxt/src/tools/project/projectSorter.ts
@@ -1,4 +1,4 @@
-import { ProjectType as ProjectType } from '@/types'
+import { ProjectType } from '@/types'
 import { ComputedRef } from 'vue'
 
 export default class ProjectSorter {
@@ -8,9 +8,15 @@ export default class ProjectSorter {
         return []
       }
 
-      return projects.value.slice().sort((a, b) => {
-        return a.priority - b.priority
+      const sortByPriority = projects.value.slice().sort((a, b) => {
+        return b.priority - a.priority
       })
+
+      return useCompanyData().isDataFull
+        ? sortByPriority.slice().sort((a, b) => {
+            return a.sectors.length <= 5 && a.sectors.length < b.sectors.length ? -1 : 1
+          })
+        : sortByPriority.reverse()
     })
   }
 }


### PR DESCRIPTION
This pull request includes several changes aimed at enhancing project filtering and sorting functionality in the application. The main updates involve adding new methods for company data selection, modifying the sorting logic, and cleaning up imports.

### Enhancements to project filtering and sorting:

* [`apps/nuxt/src/components/catalog/CatalogProjects.vue`](diffhunk://#diff-3e2e52761732bcca09ca542bf03536f1c12af126e73ec695b3e3fbe2d4ebc658R96-R101): Removed commented-out code related to project sorting by sector.
* [`apps/nuxt/src/components/project/list/ProjectCard.vue`](diffhunk://#diff-320152cb7425f7099c1b2f0c786ed12e9bf7ff57ec11a76391ba09e0993218b7R11-R31): Added badges to display the number of sectors and priority of each project.

### Store updates:

* [`apps/nuxt/src/stores/filters.ts`](diffhunk://#diff-15b5a751595a3224b78ccbef376620a40e0ae1ec425efcf13fd46a9733360e6aR27-R30): Added `isCompanyDataSelected` method to check if company data is selected and included it in the store's return object. [[1]](diffhunk://#diff-15b5a751595a3224b78ccbef376620a40e0ae1ec425efcf13fd46a9733360e6aR27-R30) [[2]](diffhunk://#diff-15b5a751595a3224b78ccbef376620a40e0ae1ec425efcf13fd46a9733360e6aR57)

### Codebase cleanup:

* [`apps/nuxt/src/tools/project/projectFilter.ts`](diffhunk://#diff-3fd288dc9b490c45e3be275e269f0355345dee73d14102cfd23b46d620a4c755L1-R1): Removed unused imports and the `byPrograms` method. [[1]](diffhunk://#diff-3fd288dc9b490c45e3be275e269f0355345dee73d14102cfd23b46d620a4c755L1-R1) [[2]](diffhunk://#diff-3fd288dc9b490c45e3be275e269f0355345dee73d14102cfd23b46d620a4c755L65-L68)
* [`apps/nuxt/src/tools/project/projectSorter.ts`](diffhunk://#diff-4129532b9285c6b9f1bfe68899a86d0e583c5b6eafac074229976f37f7d8b4ceL1-R1): Adjusted the project sorting logic to prioritize projects with higher priority and fewer sectors, and reversed the sort order if company data is not fully available. [[1]](diffhunk://#diff-4129532b9285c6b9f1bfe68899a86d0e583c5b6eafac074229976f37f7d8b4ceL1-R1) [[2]](diffhunk://#diff-4129532b9285c6b9f1bfe68899a86d0e583c5b6eafac074229976f37f7d8b4ceL11-R19)