### PR TITLE
Fix sentry : Error: Couldn't resolve component "default" at "/"

### DIFF
--- a/apps/nuxt/src/app.vue
+++ b/apps/nuxt/src/app.vue
@@ -1,7 +1,9 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import DefaultLayout from '@/layouts/default.vue'
+</script>
 
 <template>
-  <NuxtLayout>
+  <DefaultLayout>
     <NuxtPage />
-  </NuxtLayout>
+  </DefaultLayout>
 </template>


### PR DESCRIPTION
close #1667 (désolé pour le nom de branche pas logique), le probleme a l'air d'être un soucis d'import du layout default.vue qui est sensé être autodétecté mais comme par exemple ici https://github.com/nuxt/nuxt/discussions/17411 l'import automatique ne marche pas a tout les coups, je l'ai donc forcé