### PR TITLE
feat: send posthog event on external link clicked on program or project

### DIFF
--- a/apps/nuxt/src/components/program/detail/ProgramDetail.vue
+++ b/apps/nuxt/src/components/program/detail/ProgramDetail.vue
@@ -22,6 +22,7 @@
   <!-- PROGRAM INFOS -->
   <div
     v-if="program"
+    id="externalLinksTracking"
     class="fr-container fr-mt-0 fr-mt-md-3v"
   >
     <div class="fr-grid-row fr-grid-row-gutters">

--- a/apps/nuxt/src/components/program/detail/ProgramDetail.vue
+++ b/apps/nuxt/src/components/program/detail/ProgramDetail.vue
@@ -261,6 +261,7 @@ import { useProjectStore } from '@/stores/project'
 import Opportunity from '@/tools/opportunity'
 import { CompanyData } from '@/tools/companyData'
 import { storeToRefs } from 'pinia'
+import { useExternalLinkTracker } from '@/tools/analytic/useExternalLinkTracker'
 
 const programsStore = useProgramStore()
 const { projects } = storeToRefs(useProjectStore())
@@ -347,4 +348,6 @@ const scrollToProgramForm = () => {
       : Scroll.toWithTopBarOffset(teeProgramFormContainer.value)
   }
 }
+
+useExternalLinkTracker('program_external_link_clicked')
 </script>

--- a/apps/nuxt/src/components/project/details/ProjectDescription.vue
+++ b/apps/nuxt/src/components/project/details/ProjectDescription.vue
@@ -14,6 +14,7 @@
 <script setup lang="ts">
 import { ProjectType } from '@/types'
 import { Marked } from '@/tools/marked'
+import { useExternalLinkTracker } from '@/tools/analytic/useExternalLinkTracker'
 
 interface Props {
   project: ProjectType
@@ -49,4 +50,6 @@ const markdownToHtml = (text: string | undefined) => {
   }
   return ''
 }
+
+useExternalLinkTracker('project_external_link_clicked')
 </script>

--- a/apps/nuxt/src/components/project/details/ProjectDescription.vue
+++ b/apps/nuxt/src/components/project/details/ProjectDescription.vue
@@ -14,7 +14,6 @@
 <script setup lang="ts">
 import { ProjectType } from '@/types'
 import { Marked } from '@/tools/marked'
-import { useExternalLinkTracker } from '@/tools/analytic/useExternalLinkTracker'
 
 interface Props {
   project: ProjectType
@@ -50,6 +49,4 @@ const markdownToHtml = (text: string | undefined) => {
   }
   return ''
 }
-
-useExternalLinkTracker('project_external_link_clicked')
 </script>

--- a/apps/nuxt/src/components/project/details/ProjectDetail.vue
+++ b/apps/nuxt/src/components/project/details/ProjectDetail.vue
@@ -6,6 +6,7 @@
   />
   <div
     v-if="project"
+    id="externalLinksTracking"
     class="fr-col-12"
   >
     <div class="fr-container">
@@ -35,6 +36,7 @@ import { Color, ThemeId } from '@/types'
 import { MetaSeo } from '@/tools/metaSeo'
 import { Theme } from '@/tools/theme'
 import { useProjectStore } from '@/stores/project'
+import { useExternalLinkTracker } from '@/tools/analytic/useExternalLinkTracker'
 
 const { currentProject: project } = storeToRefs(useProjectStore())
 const themeColor = ref<Color | ''>()
@@ -50,4 +52,5 @@ if (project.value) {
 onBeforeRouteLeave(() => {
   useSeoMeta(MetaSeo.default())
 })
+useExternalLinkTracker('project_external_link_clicked')
 </script>

--- a/apps/nuxt/src/tools/analytic/useExternalLinkTracker.ts
+++ b/apps/nuxt/src/tools/analytic/useExternalLinkTracker.ts
@@ -1,16 +1,20 @@
 import { onMounted, onUnmounted } from 'vue'
-import Analytics from './analytics'
+// import Analytics from './analytics'
 
 export function useExternalLinkTracker(eventName: string) {
   const trackExternalLinks = (event: Event) => {
+    const trackedContainer = document.getElementById('externalLinksTracking')
+    if (!trackedContainer) return
+
     const target = event.target as HTMLElement
     const link = target.closest('a') as HTMLAnchorElement | null
 
-    if (link && link.href.startsWith('http') && !link.href.includes(window.location.hostname)) {
-      Analytics.sendEvent(eventName, eventName, {
-        url: link.href,
-        referrer: window.location.href
-      })
+    if (link && trackedContainer.contains(link) && link.href.startsWith('http') && !link.href.includes(window.location.hostname)) {
+      console.log(eventName)
+      // Analytics.sendEvent(eventName, eventName, {
+      //   url: link.href,
+      //   referrer: window.location.href
+      // })
     }
   }
 

--- a/apps/nuxt/src/tools/analytic/useExternalLinkTracker.ts
+++ b/apps/nuxt/src/tools/analytic/useExternalLinkTracker.ts
@@ -1,0 +1,24 @@
+import { onMounted, onUnmounted } from 'vue'
+import Analytics from './analytics'
+
+export function useExternalLinkTracker(eventName: string) {
+  const trackExternalLinks = (event: Event) => {
+    const target = event.target as HTMLElement
+    const link = target.closest('a') as HTMLAnchorElement | null
+
+    if (link && link.href.startsWith('http') && !link.href.includes(window.location.hostname)) {
+      Analytics.sendEvent(eventName, eventName, {
+        url: link.href,
+        referrer: window.location.href
+      })
+    }
+  }
+
+  onMounted(() => {
+    document.addEventListener('click', trackExternalLinks)
+  })
+
+  onUnmounted(() => {
+    document.removeEventListener('click', trackExternalLinks)
+  })
+}

--- a/apps/nuxt/src/tools/analytic/useExternalLinkTracker.ts
+++ b/apps/nuxt/src/tools/analytic/useExternalLinkTracker.ts
@@ -1,5 +1,5 @@
 import { onMounted, onUnmounted } from 'vue'
-// import Analytics from './analytics'
+import Analytics from './analytics'
 
 export function useExternalLinkTracker(eventName: string) {
   const trackExternalLinks = (event: Event) => {
@@ -10,11 +10,10 @@ export function useExternalLinkTracker(eventName: string) {
     const link = target.closest('a') as HTMLAnchorElement | null
 
     if (link && trackedContainer.contains(link) && link.href.startsWith('http') && !link.href.includes(window.location.hostname)) {
-      console.log(eventName)
-      // Analytics.sendEvent(eventName, eventName, {
-      //   url: link.href,
-      //   referrer: window.location.href
-      // })
+      Analytics.sendEvent(eventName, eventName, {
+        url: link.href,
+        referrer: window.location.href
+      })
     }
   }
 


### PR DESCRIPTION
Proposition de code pour tracker facilement les liens externes lorsque sur les pages program et projets. 

Le code proposé tracke trop de lien (il tracke tous les liens de la page lorsque le détail d'un programme ou d'un projet est affiché) mais sachant que certains liens sont générés à la volée via Markdown.toHtml, je ne vois pas trop d'autres solutions. 

Et c'est pas trop un problème d'emettre trop d'event posthog qu'on peut supprimer au moment où on fait les stats.  

close #1704 