### PR TITLE
fix: allow utm queries in routes where the resetQueries middleware is applied

### DIFF
--- a/apps/nuxt/src/middleware/resetQueries.ts
+++ b/apps/nuxt/src/middleware/resetQueries.ts
@@ -8,6 +8,12 @@ export default defineNuxtRouteMiddleware((to) => {
   if (currentQuery['profil-entreprise'] === 'oui') {
     newQuery['profil-entreprise'] = 'oui'
   }
+  Object.keys(currentQuery).forEach((key) => {
+    if (key.toLowerCase().startsWith('utm')) {
+      newQuery[key] = currentQuery[key] as string
+    }
+  })
+
   if (JSON.stringify(currentQuery) !== JSON.stringify(newQuery)) {
     return navigateTo({ ...to, query: newQuery })
   }


### PR DESCRIPTION
close #1816 


Proposition complémentaire pour ne garder les paramètres de query qu'une seule fois : 
```
  const isFirstVisit = !localStorage.getItem('hasVisited')

  if (isFirstVisit) {
    localStorage.setItem('hasVisited', 'true')

    Object.keys(currentQuery).forEach((key) => {
      if (key.toLowerCase().startsWith('utm')) {
        newQuery[key] = currentQuery[key] as string
      }
    })
  }
```
Je ne sais pas trop ce que tu en penses. 