### PR TITLE
fix: establishment search rare error (missing SIRET)

### DIFF
--- a/apps/nuxt/src/server/api/establishments/[query].get.ts
+++ b/apps/nuxt/src/server/api/establishments/[query].get.ts
@@ -20,7 +20,7 @@ const establishmentCached = cachedFunction(
     const establishmentResult = await new EstablishmentService().search(query, count)
     if (establishmentResult.isErr) {
       const err = establishmentResult.error
-      Monitor.error('Error in getEstablishmentBySiret', { query: query, error: err })
+      Monitor.error('Error in the establishement search', { query: query, error: err })
 
       if (err instanceof EstablishmentNotFoundError) {
         throw createError({

--- a/libs/backend-ddd/src/establishment/infrastructure/api/recherche-entreprise/recherche-entreprise.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/recherche-entreprise/recherche-entreprise.ts
@@ -56,10 +56,9 @@ export class RechercheEntreprise {
         },
         workforceRange: result.tranche_effectif_salarie
       }))
-    const resultCount = establishmentList.length ? rechercheEntrepriseSearch.total_results : 0
     return {
       establishments: establishmentList,
-      resultCount: resultCount
+      resultCount: establishmentList.length ? rechercheEntrepriseSearch.total_results : 0
     }
   }
 }

--- a/libs/backend-ddd/src/establishment/infrastructure/api/recherche-entreprise/recherche-entreprise.ts
+++ b/libs/backend-ddd/src/establishment/infrastructure/api/recherche-entreprise/recherche-entreprise.ts
@@ -36,27 +36,30 @@ export class RechercheEntreprise {
         resultCount: 0
       }
     }
-    const establishmentList = rechercheEntrepriseSearch.results.map((result: RechercheEntrepriseEstablishment) => ({
-      siret: result.siege.siret,
-      siren: result.siege.siret.substring(0, 9),
-      nic: result.siege.siret.substring(9),
-      creationDate: result.date_creation,
-      denomination: result.nom_raison_sociale || result.nom_complet,
-      nafCode: result.activite_principale,
-      legalCategory: result.nature_juridique,
-      address: {
-        streetNumber: result.siege.numero_voie,
-        streetType: result.siege.type_voie,
-        streetLabel: result.siege.libelle_voie,
-        zipCode: result.siege.code_postal,
-        cityLabel: result.siege.libelle_commune,
-        cityCode: result.siege.commune
-      },
-      workforceRange: result.tranche_effectif_salarie
-    }))
+    const establishmentList = rechercheEntrepriseSearch.results
+      .filter((result: RechercheEntrepriseEstablishment) => result.siege?.siret)
+      .map((result: RechercheEntrepriseEstablishment) => ({
+        siret: result.siege.siret,
+        siren: result.siege.siret.substring(0, 9),
+        nic: result.siege.siret.substring(9),
+        creationDate: result.date_creation,
+        denomination: result.nom_raison_sociale || result.nom_complet,
+        nafCode: result.activite_principale,
+        legalCategory: result.nature_juridique,
+        address: {
+          streetNumber: result.siege.numero_voie,
+          streetType: result.siege.type_voie,
+          streetLabel: result.siege.libelle_voie,
+          zipCode: result.siege.code_postal,
+          cityLabel: result.siege.libelle_commune,
+          cityCode: result.siege.commune
+        },
+        workforceRange: result.tranche_effectif_salarie
+      }))
+    const resultCount = establishmentList.length ? rechercheEntrepriseSearch.total_results : 0
     return {
       establishments: establishmentList,
-      resultCount: rechercheEntrepriseSearch.total_results
+      resultCount: resultCount
     }
   }
 }


### PR DESCRIPTION
Dans de très rares cas, l'api recherche entreprise renvoie des résutlat qui n'ont pas de SIRET. 
Cela cause des crashs du point d'API. 

Je propose d'ignorer ces quelques réponses. 
Si, dans le cas très peu probable, toutes 3 réponses renvoyées par l'API sont sans SIRET, je prend soin de mettre le nombre de réponse à zéro pour qu'il n'y ai pas de données contradictoires sur le front. 

Tests des deux cas avec les textes suivant dans le champ de la modale : "thones beton" et "ehpad 261".

Renaming de l'erreur sentry du point d'api establishment