### PR TITLE
fix: disable inline styles in nuxt configuration (to use cache browser)

### DIFF
--- a/apps/nuxt/nuxt.config.ts
+++ b/apps/nuxt/nuxt.config.ts
@@ -113,6 +113,7 @@ export default <DefineNuxtConfig>defineNuxtConfig({
     }
   },
   features: {
+    inlineStyles: false,
     devLogs: true
   },
   experimental: {


### PR DESCRIPTION
Ceci est un rollback, car je voulais voir un peu si ça améliorer les performances. Mais je ne suis pas convaincu et de plus, ça ne permet pas d’utiliser le cache navigateur

@ttdm Si tu as un avis sur la question ?