### PR TITLE
feat: store ce id in brevo

### DIFF
--- a/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
+++ b/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
@@ -115,15 +115,15 @@ export default class OpportunityFeatures {
           if (opportunityUpdateErr.isJust) {
             Monitor.warning('Opportunity status not updated after a transmission to a Hub', {
               error: opportunityUpdateErr.value,
-              ce_id: opportunityHubResult.value
+              idCe: opportunityHubResult.value
             })
           }
         }
       })
   }
 
-  private async _updateOpportunitySentToHub(opportunityId: OpportunityId, ceId: number): Promise<Maybe<Error | null>> {
-    return await this._opportunityRepository.update(opportunityId, { sentToOpportunityHub: true, ceId })
+  private async _updateOpportunitySentToHub(opportunityId: OpportunityId, idCe: number): Promise<Maybe<Error | null>> {
+    return await this._opportunityRepository.update(opportunityId, { sentToOpportunityHub: true, idCe })
   }
 
   private _addContactOperatorToOpportunity(opportunity: OpportunityWithContactId): OpportunityWithOperatorContactAndContactId {

--- a/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
+++ b/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
@@ -110,17 +110,22 @@ export default class OpportunityFeatures {
     void new OpportunityHubFeatures(this._opportunityHubRepositories)
       .maybeTransmitOpportunity(opportunity, data)
       .then(async (opportunityHubResult) => {
-        if (opportunityHubResult == Maybe.nothing()) {
-          const opportunityUpdateErr = await this._updateOpportunitySentToHub(opportunityId, !opportunityHubResult.isJust)
+        console.log(opportunityHubResult)
+        if (opportunityHubResult !== false && opportunityHubResult.isOk) {
+          const opportunityUpdateErr = await this._updateOpportunitySentToHub(opportunityId, opportunityHubResult.value)
           if (opportunityUpdateErr.isJust) {
-            Monitor.warning('Opportunity status not updated after a transmission to a Hub', { error: opportunityUpdateErr.value })
+            Monitor.warning('Opportunity status not updated after a transmission to a Hub', {
+              error: opportunityUpdateErr.value,
+              ce_id: opportunityHubResult.value
+            })
           }
         }
       })
   }
 
-  private async _updateOpportunitySentToHub(opportunityId: OpportunityId, success: boolean): Promise<Maybe<Error | null>> {
-    return await this._opportunityRepository.update(opportunityId, { sentToOpportunityHub: success })
+  private async _updateOpportunitySentToHub(opportunityId: OpportunityId, parnerId: number): Promise<Maybe<Error | null>> {
+    console.log('updating the brevo opportunity with the CE id : ', parnerId)
+    return await this._opportunityRepository.update(opportunityId, { sentToOpportunityHub: true, id_ce: parnerId })
   }
 
   private _addContactOperatorToOpportunity(opportunity: OpportunityWithContactId): OpportunityWithOperatorContactAndContactId {

--- a/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
+++ b/libs/backend-ddd/src/opportunity/domain/opportunityFeatures.ts
@@ -110,7 +110,6 @@ export default class OpportunityFeatures {
     void new OpportunityHubFeatures(this._opportunityHubRepositories)
       .maybeTransmitOpportunity(opportunity, data)
       .then(async (opportunityHubResult) => {
-        console.log(opportunityHubResult)
         if (opportunityHubResult !== false && opportunityHubResult.isOk) {
           const opportunityUpdateErr = await this._updateOpportunitySentToHub(opportunityId, opportunityHubResult.value)
           if (opportunityUpdateErr.isJust) {
@@ -123,9 +122,8 @@ export default class OpportunityFeatures {
       })
   }
 
-  private async _updateOpportunitySentToHub(opportunityId: OpportunityId, parnerId: number): Promise<Maybe<Error | null>> {
-    console.log('updating the brevo opportunity with the CE id : ', parnerId)
-    return await this._opportunityRepository.update(opportunityId, { sentToOpportunityHub: true, id_ce: parnerId })
+  private async _updateOpportunitySentToHub(opportunityId: OpportunityId, ceId: number): Promise<Maybe<Error | null>> {
+    return await this._opportunityRepository.update(opportunityId, { sentToOpportunityHub: true, ceId })
   }
 
   private _addContactOperatorToOpportunity(opportunity: OpportunityWithContactId): OpportunityWithOperatorContactAndContactId {

--- a/libs/backend-ddd/src/opportunity/domain/types.ts
+++ b/libs/backend-ddd/src/opportunity/domain/types.ts
@@ -15,7 +15,7 @@ export type OpportunityDetailsShort = Omit<OpportunityDetails, 'linkToPage' | 'l
 
 export interface OpportunityUpdateAttributes {
   sentToOpportunityHub: boolean
-  id_ce: number
+  ceId: number
 }
 
 export interface ContactId {

--- a/libs/backend-ddd/src/opportunity/domain/types.ts
+++ b/libs/backend-ddd/src/opportunity/domain/types.ts
@@ -15,6 +15,7 @@ export type OpportunityDetailsShort = Omit<OpportunityDetails, 'linkToPage' | 'l
 
 export interface OpportunityUpdateAttributes {
   sentToOpportunityHub: boolean
+  id_ce: number
 }
 
 export interface ContactId {

--- a/libs/backend-ddd/src/opportunity/domain/types.ts
+++ b/libs/backend-ddd/src/opportunity/domain/types.ts
@@ -15,7 +15,7 @@ export type OpportunityDetailsShort = Omit<OpportunityDetails, 'linkToPage' | 'l
 
 export interface OpportunityUpdateAttributes {
   sentToOpportunityHub: boolean
-  ceId: number
+  idCe: number
 }
 
 export interface ContactId {

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -69,7 +69,6 @@ const requestUpdateDeal = async (dealId: OpportunityId, attributes: DealUpdateAt
   const responseResult = await new BrevoAPI().PatchDeal(dealId.id, {
     attributes: attributes
   })
-
   if (responseResult.isErr) {
     Monitor.error('Error in Brevo PatchDeal api call', { dealID: dealId.id, attributes, error: responseResult.error })
   }
@@ -106,7 +105,8 @@ const convertDomainToBrevoDeal = (domainAttributes: OpportunityWithOperatorConta
 
 const convertDomainToBrevoDealUpdate = (domainUpdateAttributes: OpportunityUpdateAttributes): DealUpdateAttributes => {
   return {
-    envoy: domainUpdateAttributes.sentToOpportunityHub
+    envoy: domainUpdateAttributes.sentToOpportunityHub,
+    idce: domainUpdateAttributes.id_ce.toString()
   }
 }
 

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -69,6 +69,7 @@ const requestUpdateDeal = async (dealId: OpportunityId, attributes: DealUpdateAt
   const responseResult = await new BrevoAPI().PatchDeal(dealId.id, {
     attributes: attributes
   })
+
   if (responseResult.isErr) {
     Monitor.error('Error in Brevo PatchDeal api call', { dealID: dealId.id, attributes, error: responseResult.error })
   }
@@ -106,7 +107,7 @@ const convertDomainToBrevoDeal = (domainAttributes: OpportunityWithOperatorConta
 const convertDomainToBrevoDealUpdate = (domainUpdateAttributes: OpportunityUpdateAttributes): DealUpdateAttributes => {
   return {
     envoy: domainUpdateAttributes.sentToOpportunityHub,
-    idce: domainUpdateAttributes.id_ce.toString()
+    idce: domainUpdateAttributes.ceId.toString()
   }
 }
 

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/brevoDeal.ts
@@ -107,7 +107,7 @@ const convertDomainToBrevoDeal = (domainAttributes: OpportunityWithOperatorConta
 const convertDomainToBrevoDealUpdate = (domainUpdateAttributes: OpportunityUpdateAttributes): DealUpdateAttributes => {
   return {
     envoy: domainUpdateAttributes.sentToOpportunityHub,
-    idce: domainUpdateAttributes.ceId.toString()
+    idce: domainUpdateAttributes.idCe.toString()
   }
 }
 

--- a/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
+++ b/libs/backend-ddd/src/opportunity/infrastructure/api/brevo/types.ts
@@ -60,6 +60,7 @@ export interface DealAttributes {
 
 export interface DealUpdateAttributes {
   envoy: boolean
+  idce: string
 }
 
 export enum BrevoCompanySize {

--- a/libs/backend-ddd/src/opportunityHub/domain/opportunityHubFeatures.ts
+++ b/libs/backend-ddd/src/opportunityHub/domain/opportunityHubFeatures.ts
@@ -1,6 +1,6 @@
 import { OpportunityHubRepository } from './spi'
 import { OpportunityWithContactId } from '../../opportunity/domain/types'
-import { Maybe } from 'true-myth'
+import { Result } from 'true-myth'
 import { PlaceDesEntreprises } from '../infrastructure/api/placedesentreprises/placeDesEntreprises'
 import { OpportunityType } from '@tee/common'
 import { OpportunityAssociatedData } from '../../opportunity/domain/opportunityAssociatedData'
@@ -14,7 +14,7 @@ export default class OpportunityHubFeatures {
   public async maybeTransmitOpportunity(
     opportunity: OpportunityWithContactId,
     opportunityObject: OpportunityAssociatedData
-  ): Promise<Maybe<Error> | false> {
+  ): Promise<Result<number, Error> | false> {
     switch (opportunity.type) {
       case OpportunityType.Program:
         for (const opportunityHubRepository of this._opportunityHubRepositories) {

--- a/libs/backend-ddd/src/opportunityHub/domain/spi.ts
+++ b/libs/backend-ddd/src/opportunityHub/domain/spi.ts
@@ -1,12 +1,12 @@
 import { OpportunityWithContactId } from '../../opportunity/domain/types'
-import { Maybe } from 'true-myth'
+import { Result } from 'true-myth'
 import { Operators } from '@tee/data'
 import { Opportunity } from '@tee/common'
 import { OpportunityAssociatedData } from '../../opportunity/domain/opportunityAssociatedData'
 
 export interface OpportunityHubRepository {
   get operatorNames(): Operators[] | Error
-  transmitOpportunity: (opportunity: Opportunity, opportunityObject: OpportunityAssociatedData) => Promise<Maybe<Error>>
+  transmitOpportunity: (opportunity: Opportunity, opportunityObject: OpportunityAssociatedData) => Promise<Result<number, Error>>
   support: (opportunityObject: OpportunityAssociatedData) => boolean
   shouldTransmit: (opportunity: OpportunityWithContactId, opportunityObject: OpportunityAssociatedData) => Promise<boolean>
 }

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/opportunityHubAbstract.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/opportunityHubAbstract.ts
@@ -2,7 +2,7 @@ import { Operators } from '@tee/data'
 import { AxiosInstance } from 'axios'
 import { OpportunityHubRepository } from '../../domain/spi'
 import { OpportunityWithContactId } from '../../../opportunity/domain/types'
-import { Maybe } from 'true-myth'
+import { Result } from 'true-myth'
 import { Opportunity } from '@tee/common'
 import { OpportunityAssociatedData } from '../../../opportunity/domain/opportunityAssociatedData'
 
@@ -30,7 +30,7 @@ export default abstract class OpportunityHubAbstract implements OpportunityHubRe
   public abstract transmitOpportunity: (
     opportunity: Opportunity,
     opportunityAssociatedData: OpportunityAssociatedData
-  ) => Promise<Maybe<Error>>
+  ) => Promise<Result<number, Error>>
 
   get operatorNames(): Operators[] | Error {
     return this._operatorNames

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -77,7 +77,7 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
       })
       const status = response.status
       if (status != 200) {
-        Monitor.error('Error creating an opportunity at CE during CE API Call', { CeReponse: response })
+        Monitor.error('Error creating an opportunity at CE during CE API Call', { CeReponse: response, payload: payload })
 
         return Result.err(new Error('PDE Api Error ' + status))
       }
@@ -85,6 +85,11 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
       if (typeof solicitationId === 'number') {
         return Result.ok(solicitationId)
       } else {
+        Monitor.error('Unable to get the Id from CE while transmitting the opportunity using the API', {
+          CeReponse: response,
+          payload: payload
+        })
+
         return Result.err(new Error('Invalid response format: missing solicitation_id'))
       }
     } catch (exception: unknown) {

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -85,7 +85,7 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
       if (typeof solicitationId === 'number') {
         return Result.ok(solicitationId)
       } else {
-        Monitor.error('Unable to get the Id from CE while transmitting the opportunity using the API', {
+        Monitor.warning('Unable to retrieve the Id from CE while transmitting the opportunity using the API', {
           CeReponse: response,
           payload: payload
         })

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -1,9 +1,9 @@
-import { Maybe, Result } from 'true-myth'
+import { Result } from 'true-myth'
 import axios, { AxiosInstance, RawAxiosRequestHeaders } from 'axios'
 import AxiosHeaders from '../../../../common/infrastructure/api/axiosHeaders'
 import { ensureError, handleException } from '../../../../common/domain/error/errors'
 import Config from '../../../../config'
-import { GetLandingResponseData, Subject, subjectToIdMapping, CreateSolicitationApiBody } from './types'
+import { SolicitationResponseData, Subject, subjectToIdMapping, CreateSolicitationApiBody } from './types'
 import { OpportunityWithContactId } from '../../../../opportunity/domain/types'
 import OpportunityHubAbstract from '../opportunityHubAbstract'
 import { ProgramService } from '../../../../program/application/programService'
@@ -47,7 +47,10 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
     return !reachTransmissionLimit
   }
 
-  public transmitOpportunity = async (opportunity: Opportunity, opportunityData: OpportunityAssociatedData): Promise<Maybe<Error>> => {
+  public transmitOpportunity = async (
+    opportunity: Opportunity,
+    opportunityData: OpportunityAssociatedData
+  ): Promise<Result<number, Error>> => {
     let maybePayload
     if (opportunityData.isProgram()) {
       maybePayload = this._createProgramRequestBody(opportunity, opportunityData.data)
@@ -56,17 +59,17 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
     } else if (opportunityData.isCustomProject()) {
       maybePayload = this._createProjectRequestBody(opportunity, opportunityData.data.title)
     } else {
-      return Maybe.of(Error("Canno't transmit to PDE an opportunity of type" + opportunity.type))
+      return Result.err(Error("Canno't transmit to PDE an opportunity of type" + opportunity.type))
     }
     if (maybePayload.isErr) {
-      return Maybe.of(maybePayload.error)
+      return Result.err(maybePayload.error)
     }
     return await this._sendOpportunity(maybePayload.value)
   }
 
-  private _sendOpportunity = async (payload: CreateSolicitationApiBody): Promise<Maybe<Error>> => {
+  private _sendOpportunity = async (payload: CreateSolicitationApiBody): Promise<Result<number, Error>> => {
     try {
-      const response = await this._axios.request<GetLandingResponseData>({
+      const response = await this._axios.request<SolicitationResponseData>({
         method: 'POST',
         url: `/solicitations`,
         data: payload,
@@ -76,14 +79,20 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
       if (status != 200) {
         Monitor.error('Error creating an opportunity at CE during CE API Call', { CeReponse: response })
 
-        return Maybe.of(Error('PDE Api Error ' + status))
+        return Result.err(new Error('PDE Api Error ' + status))
+      }
+      console.log(status)
+      console.log(response.data)
+      const solicitationId = response.data?.data?.solicitation_id
+      if (typeof solicitationId === 'number') {
+        return Result.ok(solicitationId)
       } else {
-        return Maybe.nothing()
+        return Result.err(new Error('Invalid response format: missing solicitation_id'))
       }
     } catch (exception: unknown) {
       Monitor.exception(ensureError(exception))
 
-      return Maybe.of(handleException(exception))
+      return Result.err(handleException(exception))
     }
   }
 

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/placeDesEntreprises.ts
@@ -81,8 +81,6 @@ export class PlaceDesEntreprises extends OpportunityHubAbstract {
 
         return Result.err(new Error('PDE Api Error ' + status))
       }
-      console.log(status)
-      console.log(response.data)
       const solicitationId = response.data?.data?.solicitation_id
       if (typeof solicitationId === 'number') {
         return Result.ok(solicitationId)

--- a/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/types.ts
+++ b/libs/backend-ddd/src/opportunityHub/infrastructure/api/placedesentreprises/types.ts
@@ -1,25 +1,8 @@
-export interface GetLandingResponseData {
-  data: Landing[]
-  metadata: Metadata
-}
-
-interface Theme {
-  id: number
-  title: string
-  slug: string
-  description: string
-}
-
-export interface Landing {
-  id: number
-  title: string
-  slug: string
-  partner_url: string
-  landing_themes: Theme[]
-}
-
-interface Metadata {
-  total_results: number
+export interface SolicitationResponseData {
+  data: {
+    solicitation_id: number
+    institutions_partenaires: string[]
+  }
 }
 
 export enum Subject {

--- a/libs/backend-ddd/tests/opportunityHub/infrastructure/api/mock/placeDesEntreprises.ts
+++ b/libs/backend-ddd/tests/opportunityHub/infrastructure/api/mock/placeDesEntreprises.ts
@@ -1,6 +1,6 @@
 import { Operators } from '@tee/data'
 import { Objective } from '@tee/common'
-import { Maybe } from 'true-myth'
+import { Result } from 'true-myth'
 import { AxiosInstance } from 'axios'
 import { Subject, subjectToIdMapping } from '../../../../../src/opportunityHub/infrastructure/api/placedesentreprises/types'
 import OpportunityHubAbstract from '../../../../../src/opportunityHub/infrastructure/api/opportunityHubAbstract'
@@ -33,8 +33,8 @@ export class PlaceDesEntreprisesTest extends OpportunityHubAbstract {
     return true
   }
 
-  public transmitOpportunity = async (): Promise<Maybe<Error>> => {
-    return Maybe.nothing()
+  public transmitOpportunity = async (): Promise<Result<number, Error>> => {
+    return Result.ok(-1)
   }
 
   async reachedDailyContactTransmissionLimit(): Promise<boolean> {

--- a/libs/data/tools/brevoExport/brevoExport.py
+++ b/libs/data/tools/brevoExport/brevoExport.py
@@ -9,7 +9,7 @@ import sib_api_v3_sdk
 from sib_api_v3_sdk.rest import ApiException
 
 # parameters
-BREVO_API_KEY_FILE_PATH = "../../../../apps/backend/.env"
+BREVO_API_KEY_FILE_PATH = "../../../../apps/nuxt/.env"
 REFRESH_CONTACTS = True  # True = use brevo API, False = use local file
 REFRESH_DEALS = True  # True = use brevo API, False = use local file
 EXPORT_TO_JSON = True


### PR DESCRIPTION
Récupère l'identifiant Conseiller Entreprise et le transmet à Brevo. 

Le fait de parler directement de _ceId_ dans le code peut être discutable mais ça me parait important de bien identifier l'id de chaque partenaire et de ne pas avoir de "partnerId" qui peut facilement être confondu. 

L'implém à été testé;. 
Voir le dernier deal sur la pipeline de test de brevo. Pour simplifier la vérification, l'idce a été rajotué en temps que dernière colonne dans le tableau brevo (à cacher à nouveau lors de la mise en prod)

close #1926 