### PR TITLE
feat: add favicon and web app manifest links to nuxt configuration

### DIFF
--- a/apps/nuxt/nuxt.config.ts
+++ b/apps/nuxt/nuxt.config.ts
@@ -23,7 +23,13 @@ export default <DefineNuxtConfig>defineNuxtConfig({
     head: {
       htmlAttrs: {
         lang: 'fr'
-      }
+      },
+      link: [
+        { rel: 'icon', type: 'image/svg+xml', href: '/favicon.svg' },
+        { rel: 'shortcut icon', type: 'image/x-icon', href: '/favicon.ico' },
+        { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' },
+        { rel: 'manifest', href: '/manifest.webmanifest' }
+      ]
     }
   },
   routeRules: {


### PR DESCRIPTION
Cette pull request met à jour le fichier `nuxt.config.ts` pour améliorer la configuration de la section `<head>` de l’application Nuxt en ajoutant la prise en charge de différents liens favicon et du manifeste web app.

### Améliorations de la configuration :

* [`apps/nuxt/nuxt.config.ts`](diffhunk://#diff-f461d740e09cfb2bc7ab32a29f66921fc84a62f1f75f0fb6e1189a77abae3a4fL26-R32) : Ajout de plusieurs éléments `<link>` à la configuration `head`, incluant la prise en charge des favicons SVG et ICO, d’une icône Apple touch et d’un fichier manifeste web app.