### PR TITLE
Feat: improve link checks in programs

### DIFF
--- a/libs/data/src/common/validators/linkValidator.ts
+++ b/libs/data/src/common/validators/linkValidator.ts
@@ -2,13 +2,22 @@ import axios from 'axios'
 import https from 'https'
 import { chromium } from 'playwright'
 import { RequestInit as NodeFetchRequestInit } from 'node-fetch'
+import { Logger } from '../logger/logger'
+import { LogLevel } from '../logger/types'
 
 export class LinkValidator {
-  public static forceHttps(link) {
+  public static forceHttps(link: string) {
     return link.replace(/^http:\/\//i, 'https://')
   }
 
-  public static async findAndValidateLinks(inputText: string): string[] {
+  public static async logInvalidLinks(inputText: string, logger: Logger, logLevel: LogLevel, fieldName: string, id: string, rowId: number) {
+    const invalidLinks = await LinkValidator.findAndValidateLinks(inputText)
+    for (const link of invalidLinks) {
+      logger.log(logLevel, 'Lien invalide détecté dans le champ ' + fieldName, id, rowId, `[Lien cassé](${link})`)
+    }
+  }
+
+  public static async findAndValidateLinks(inputText: string): Promise<string[]> {
     const urlRegex = /(https?:\/\/[^\s]+)/g
     const foundLinks = inputText.match(urlRegex) || []
     const invalidLinks = []

--- a/libs/data/src/common/validators/linkValidator.ts
+++ b/libs/data/src/common/validators/linkValidator.ts
@@ -10,14 +10,21 @@ export class LinkValidator {
     return link.replace(/^http:\/\//i, 'https://')
   }
 
-  public static async logInvalidLinks(inputText: string, logger: Logger, logLevel: LogLevel, fieldName: string, id: string, rowId: number) {
-    const invalidLinks = await LinkValidator.findAndValidateLinks(inputText)
+  public static async logInvalidLinks(
+    inputText: string,
+    logger: Logger,
+    logLevel: LogLevel,
+    fieldName: string,
+    id: string,
+    rowId: number
+  ): Promise<void> {
+    const invalidLinks = await LinkValidator.findInvalidLinks(inputText)
     for (const link of invalidLinks) {
       logger.log(logLevel, 'Lien invalide détecté dans le champ ' + fieldName, id, rowId, `[Lien cassé](${link})`)
     }
   }
 
-  public static async findAndValidateLinks(inputText: string): Promise<string[]> {
+  public static async findInvalidLinks(inputText: string): Promise<string[]> {
     const urlRegex = /(https?:\/\/[^\s]+)/g
     const foundLinks = inputText.match(urlRegex) || []
     const invalidLinks = []

--- a/libs/data/src/program/yamlGenerator/eligibilityGenerator.ts
+++ b/libs/data/src/program/yamlGenerator/eligibilityGenerator.ts
@@ -21,16 +21,14 @@ export async function setEligibility(generator: CoreGenerator) {
 }
 
 async function setOtherEligibilityCriteria(generator: CoreGenerator): Promise<string[]> {
-  const invalidLinks = await LinkValidator.findAndValidateLinks(generator.program['Eligibilité Spécifique'])
-  for (const link of invalidLinks) {
-    generator.logger.log(
-      LogLevel.Minor,
-      `Lien invalide détecté dans le champ "éligibilité spécifique" : ${link}`,
-      generator.program['Id fiche dispositif'],
-      generator.program.id
-    )
-  }
-
+  await LinkValidator.logInvalidLinks(
+    generator.program['Eligibilité Spécifique'],
+    generator.logger,
+    LogLevel.Minor,
+    'Eligibilité Spécifique',
+    generator.program['Id fiche dispositif'],
+    generator.program.id
+  )
   const criteriaList = generator.program['Eligibilité Spécifique'].split('\n').map((criteria) => criteria.trim())
   if (criteriaList.filter((criteria) => !criteria.startsWith('- ')).length) {
     generator.logger.log(

--- a/libs/data/src/program/yamlGenerator/objectiveGenerator.ts
+++ b/libs/data/src/program/yamlGenerator/objectiveGenerator.ts
@@ -3,6 +3,7 @@ import { CoreGenerator } from './coreGenerator'
 import { validateObjectiveLink } from './linksValidator'
 import { LinkValidator } from '../../common/validators/linkValidator'
 import { LogLevel } from '../../common/logger/types'
+import z from 'zod'
 
 export async function setObjectives(generator: CoreGenerator) {
   const objectifs: YamlObjective[] = []
@@ -37,7 +38,10 @@ async function parseStep(step: string, stepId: number, generator: CoreGenerator)
       }
       const match = line.match(/\[(.*?)\]\((.*?)\)/)
       if (match) {
-        validateObjectiveLink(match[2], stepId, generator)
+        const isUrl = z.string().url().safeParse(match[2]).success
+        if (isUrl) {
+          validateObjectiveLink(match[2], stepId, generator)
+        }
         return { lien: match[2], texte: match[1] }
       }
       return null

--- a/libs/data/src/program/yamlGenerator/objectiveGenerator.ts
+++ b/libs/data/src/program/yamlGenerator/objectiveGenerator.ts
@@ -20,15 +20,14 @@ export async function setObjectives(generator: CoreGenerator) {
 async function parseStep(step: string, stepId: number, generator: CoreGenerator): Promise<YamlObjective> {
   const lines = step.split('\n')
   const description = lines[0].substring(2)
-  const invalidLinks = await LinkValidator.findAndValidateLinks(description)
-  for (const link of invalidLinks) {
-    generator.logger.log(
-      LogLevel.Minor,
-      `Lien invalide détecté dans le champ "Objectif ${stepId}" : ${link}`,
-      generator.program['Id fiche dispositif'],
-      generator.program.id
-    )
-  }
+  await LinkValidator.logInvalidLinks(
+    description,
+    generator.logger,
+    LogLevel.Minor,
+    `"Objectif ${stepId}"`,
+    generator.program['Id fiche dispositif'],
+    generator.program.id
+  )
 
   const liens = lines
     .slice(1)

--- a/libs/data/src/program/yamlGenerator/objectiveGenerator.ts
+++ b/libs/data/src/program/yamlGenerator/objectiveGenerator.ts
@@ -39,7 +39,8 @@ async function parseStep(step: string, stepId: number, generator: CoreGenerator)
       const match = line.match(/\[(.*?)\]\((.*?)\)/)
       if (match) {
         const isUrl = z.string().url().safeParse(match[2]).success
-        if (isUrl) {
+        const isEmail = match[2].startsWith('mailto:')
+        if (isUrl && !isEmail) {
           validateObjectiveLink(match[2], stepId, generator)
         }
         return { lien: match[2], texte: match[1] }


### PR DESCRIPTION
- Détection des urls mortes dans de nouveaux champs. Couverture de tous les champs réécrits en markdown, et de tous les champs étant spécialement dédiés aux liens. 
- Petite refacto pour proposer de loger directement dans le LinkValidator. 
- Petites amélioration de naming
- Petites amélioration sur les annotations de types
- Suppression des tests de validité effectués à tort dans les étapes sur les mails. 


Info tech: 
const myString : 'mailto:pda.hebergement@auvergnerhonealpes.fr'
        const isEmail = z.string().email().safeParse(myString).success
        const isUrl = z.string().url().safeParse(myString).success
        console.log(match[2], isEmail, isUrl)
Renvoie :  false true
Cette string n'est donc pas un mail mais une url valide pour zod.
D'ou le check isEmail via : startwith(mailto) . 

La génération de programme a été testée suite aux modifs effectuées et les logs vérifiés. 

close #1865 

