### PR TITLE
chore: security update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/node": "22.19.11",
         "@unhead/schema-org": "2.1.12",
         "@vueuse/core": "13.9.0",
-        "axios": "1.13.5",
+        "axios": "1.13.6",
         "chart.js": "4.5.1",
         "dotenv": "16.6.1",
         "markdown-it": "14.1.1",
@@ -18555,9 +18555,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/node": "22.19.11",
     "@unhead/schema-org": "2.1.12",
     "@vueuse/core": "13.9.0",
-    "axios": "1.13.5",
+    "axios": "1.13.6",
     "chart.js": "4.5.1",
     "dotenv": "16.6.1",
     "markdown-it": "14.1.1",


### PR DESCRIPTION
## Mise à jour de sécurité des dépendances

Résolution des alertes Dependabot par mise à jour des sous-dépendances dans le `package-lock.json`.

### Dépendances mises à jour

| Package | Ancienne version | Nouvelle version | PR Dependabot |
|---|---|---|---|
| `simple-git` | 3.32.2 | 3.33.0 | #2532 |
| `h3` | 1.15.5 | 1.15.8 | #2550 |
| `devalue` | 5.6.3 | 5.6.4 | #2544 |
| `flatted` | 3.3.3 | 3.4.2 | #2545 |
| `unhead` / `@unhead/vue` / `@unhead/schema-org` | — | 2.1.12 | #2543 |
| `tar` | 7.5.9 | 7.5.11 | #2535 |
| `fast-xml-parser` / `@aws-sdk/xml-builder` | — | — | #2528 |
| `axios` | 1.13.5 | 1.13.6 | #2527 |