### PR TITLE
feat: customize iframe siret example per integrator (#2663)

### DIFF
--- a/apps/nuxt/src/components/identification/TeeRegisterSiret.vue
+++ b/apps/nuxt/src/components/identification/TeeRegisterSiret.vue
@@ -87,8 +87,11 @@ import CompanySearch from '@/tools/companySearch'
 
 interface Props {
   title?: string
+  example?: string
 }
-defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  example: 'Fromagerie Sanzot Angers'
+})
 
 const defaultSearchValue = {
   establishments: [],
@@ -96,7 +99,7 @@ const defaultSearchValue = {
 }
 
 const queryValue = ref<string | undefined>()
-const hint = `ex : "Fromagerie Sanzot Angers" ou N° SIRET "130 025 265 00013"`
+const hint = computed(() => `ex : "${props.example}" ou N° SIRET "130 025 265 00013"`)
 
 const isLoading = ref<boolean>(false)
 const requestResponses = ref<EstablishmentSearch>(defaultSearchValue)

--- a/apps/nuxt/src/pages/demo/iframe.client.vue
+++ b/apps/nuxt/src/pages/demo/iframe.client.vue
@@ -16,13 +16,13 @@
       id="transition-ecologique-entreprise"
       :src="Iframe.getScript()"
       data-type="siret"
-      data-source="tee"
+      data-source="anap"
     />
     <Script
       id="transition-ecologique-entreprise"
       :src="Iframe.getScript()"
       data-type="siret-profile"
-      data-source="tee"
+      data-source="anap"
     />
     <div class="fr-mb-2v"></div>
   </div>

--- a/apps/nuxt/src/pages/iframe/siret/index.vue
+++ b/apps/nuxt/src/pages/iframe/siret/index.vue
@@ -24,6 +24,7 @@
       <div class="fr-col-sm-10 fr-col-md-9 fr-col-lg-8 fr-col-xl-7 fr-col-12">
         <TeeRegisterSiret
           v-if="registerStep === 1"
+          :example="siretExample"
           @select-establishment="updateEstablishment"
           @manual-register="setManualRegister"
         />
@@ -60,6 +61,12 @@ const route = useRoute()
 const mainStep = computed<number>(() => {
   return route.query.step === '2' ? 2 : 1
 })
+
+// Allow integrators to display a tailored company example through the iframe utm_source
+const siretExampleBySource: Record<string, string> = {
+  anap: 'Centre Hospitalier de Narbonne'
+}
+const siretExample = computed<string | undefined>(() => siretExampleBySource[route.query.utm_source as string])
 
 if (import.meta.client) {
   Analytics.sendEvent('generic_iframe_siret_view', {


### PR DESCRIPTION
## Contexte

Closes #2663

L'ANAP souhaite pouvoir modifier l'exemple « Fromagerie Sanzot Angers » affiché dans le champ de saisie SIRET du widget iframe.

## Changements

- `TeeRegisterSiret.vue` : ajout d'une prop optionnelle `example` (défaut `Fromagerie Sanzot Angers`), le `hint` devient un `computed` qui l'interpole.
- `pages/iframe/siret/index.vue` : l'exemple est choisi selon `utm_source` via une map. Pour `utm_source=anap`, le champ affiche « Centre Hospitalier de Narbonne ».

## Intégration

Côté intégrateur, il suffit de poser `data-source="anap"` sur le script d'intégration (remonté en `utm_source=anap` par `iframe.ts`). La map rend l'ajout d'autres intégrateurs trivial.

## Vérifications

- `lint --fix` OK
- `type-check` OK