### PR TITLE
fix(ci): corriger l'échec "Argument list too long" des PR auto de données

### DIFF
--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -17,9 +17,9 @@ jobs:
         node-version: ['22.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -61,14 +61,14 @@ jobs:
 
       - name: Upload full validation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: projectGeneration-log
           path: libs/data/projectGeneration.log
           retention-days: 90
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           base: main
           branch: chore/update_projects
@@ -84,9 +84,9 @@ jobs:
         node-version: ['22.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -128,14 +128,14 @@ jobs:
 
       - name: Upload full validation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: programYaml-log
           path: libs/data/programYaml.log
           retention-days: 90
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           base: main
           branch: chore/update_programs
@@ -151,9 +151,9 @@ jobs:
         node-version: ['22.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -166,7 +166,7 @@ jobs:
         run: npm run generate:testimonies
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           base: main
           branch: chore/update_testimonies
@@ -186,9 +186,9 @@ jobs:
         node-version: ['22.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -228,14 +228,14 @@ jobs:
 
       - name: Upload full validation log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: generateFaqJson-log
           path: libs/data/generateFaqJson.log
           retention-days: 90
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           base: main
           branch: chore/update_faq
@@ -251,9 +251,9 @@ jobs:
         node-version: ['22.x']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.github/workflows/update_data.yml
+++ b/.github/workflows/update_data.yml
@@ -33,12 +33,39 @@ jobs:
           BASEROW_TOKEN: '${{secrets.BASEROW_TOKEN}}'
         run: npm run generate:projects
 
-      - name: Read Log File
-        id: read-log
+      # Build the PR body in a file outside the workspace so it is NOT committed
+      # to the PR, and truncate the log to stay under GitHub's 65536-char body limit.
+      - name: Build PR body
         run: |
-          echo "log_content<<EOF" >> $GITHUB_ENV
-          cat libs/data/projectGeneration.log >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          log_file=libs/data/projectGeneration.log
+          body_file="${{ runner.temp }}/pr-body.md"
+          {
+            echo "Cette pull request a été créée automatiquement pour mettre à jour les projets."
+            echo ""
+            echo "### :warning: Merci de bien vérifier les changements avant de merge. :warning:"
+            echo ""
+            echo "Essayer de limiter le rennomage de slug. Chaque slug rennomé \"casse\" des liens que peuvent avoir conservés les utilisateurs."
+            echo ""
+            echo "### Liste de points problématiques automatiquement détectés:"
+            echo ""
+            echo ":fire: :fire: :fire: :fire: critique"
+            echo ":fire: :fire:  important"
+            echo ":fire: mineur"
+            echo ":warning:  info"
+            echo ""
+            head -c 55000 "$log_file"
+            if [ "$(wc -c < "$log_file")" -gt 55000 ]; then
+              printf '\n\n> :scissors: **Log tronqué.** Log complet dans l'"'"'artefact `projectGeneration-log` de [ce run](%s/%s/actions/runs/%s).\n' "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}"
+            fi
+          } > "$body_file"
+
+      - name: Upload full validation log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: projectGeneration-log
+          path: libs/data/projectGeneration.log
+          retention-days: 90
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -47,22 +74,7 @@ jobs:
           branch: chore/update_projects
           commit-message: 'chore: update projects'
           title: 'chore: update projects'
-          body: |
-            Cette pull request a été crée automatiquement pour mettre à jour les projets.
-
-            ### :warning: Merci de bien vérifier les changements avant de merge. :warning:
-
-            Essayer de limiter le rennomage de slug. Chaque slug rennomé "casse" des liens que peuvent avoir conservés les utilisateurs.
-
-            ### Liste de points problématiques automatiquement détectés:
-
-            :fire: :fire: :fire: :fire: critique
-            :fire: :fire:  important
-            :fire: mineur
-            :warning:  info
-
-            ${{ env.log_content }}
-
+          body-path: ${{ runner.temp }}/pr-body.md
           draft: false
 
   update-programs:
@@ -88,12 +100,39 @@ jobs:
           BASEROW_TOKEN: '${{secrets.BASEROW_TOKEN}}'
         run: npm run generate:programs
 
-      - name: Read Log File
-        id: read-log
+      # Build the PR body in a file outside the workspace so it is NOT committed
+      # to the PR, and truncate the log to stay under GitHub's 65536-char body limit.
+      - name: Build PR body
         run: |
-          echo "log_content<<EOF" >> $GITHUB_ENV
-          cat libs/data/programYaml.log >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          log_file=libs/data/programYaml.log
+          body_file="${{ runner.temp }}/pr-body.md"
+          {
+            echo "Cette pull request a été créée automatiquement pour mettre à jour les dispositifs."
+            echo ""
+            echo "### :warning: Merci de bien vérifier les changements avant de merge. :warning:"
+            echo ""
+            echo "Attention en particulier aux changements de slugs qui vont créer de nouveaux dispositifs au lieu de réécrire un dispositif existant."
+            echo ""
+            echo "### Liste de points problématiques automatiquement détectés:"
+            echo ""
+            echo ":fire: :fire: :fire: :fire: critique"
+            echo ":fire: :fire:  important"
+            echo ":fire: mineur"
+            echo ":warning:  info"
+            echo ""
+            head -c 55000 "$log_file"
+            if [ "$(wc -c < "$log_file")" -gt 55000 ]; then
+              printf '\n\n> :scissors: **Log tronqué.** Log complet dans l'"'"'artefact `programYaml-log` de [ce run](%s/%s/actions/runs/%s).\n' "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}"
+            fi
+          } > "$body_file"
+
+      - name: Upload full validation log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: programYaml-log
+          path: libs/data/programYaml.log
+          retention-days: 90
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -102,21 +141,7 @@ jobs:
           branch: chore/update_programs
           commit-message: 'chore: update programs'
           title: 'chore: update programs'
-          body: |
-            Cette pull request a été crée automatiquement pour mettre à jour les dispositifs.
-
-            ### :warning: Merci de bien vérifier les changements avant de merge. :warning:
-
-            Attention en particulier aux changements de slugs qui vont créer de nouveaux dispositifs au lieu de reéécrire un dispositif existant.
-
-            ### Liste de points problématiques automatiquement détectés:
-
-            :fire: :fire: :fire: :fire: critique
-            :fire: :fire:  important
-            :fire: mineur
-            :warning:  info
-
-            ${{ env.log_content }}
+          body-path: ${{ runner.temp }}/pr-body.md
           draft: false
 
   update-testimonies:
@@ -177,12 +202,37 @@ jobs:
           BASEROW_TOKEN: '${{secrets.BASEROW_TOKEN}}'
         run: npm run generate:faq
 
-      - name: Read Log File
-        id: read-log
+      # Build the PR body in a file outside the workspace so it is NOT committed
+      # to the PR, and truncate the log to stay under GitHub's 65536-char body limit.
+      - name: Build PR body
         run: |
-          echo "log_content<<EOF" >> $GITHUB_ENV
-          cat libs/data/generateFaqJson.log >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          log_file=libs/data/generateFaqJson.log
+          body_file="${{ runner.temp }}/pr-body.md"
+          {
+            echo "Cette pull request a été créée automatiquement pour mettre à jour les FAQ."
+            echo ""
+            echo "### :warning: Merci de bien vérifier les changements avant de merge. :warning:"
+            echo ""
+            echo "### Liste de points problématiques automatiquement détectés:"
+            echo ""
+            echo ":fire: :fire: :fire: :fire: critique"
+            echo ":fire: :fire:  important"
+            echo ":fire: mineur"
+            echo ":warning:  info"
+            echo ""
+            head -c 55000 "$log_file"
+            if [ "$(wc -c < "$log_file")" -gt 55000 ]; then
+              printf '\n\n> :scissors: **Log tronqué.** Log complet dans l'"'"'artefact `generateFaqJson-log` de [ce run](%s/%s/actions/runs/%s).\n' "${{ github.server_url }}" "${{ github.repository }}" "${{ github.run_id }}"
+            fi
+          } > "$body_file"
+
+      - name: Upload full validation log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generateFaqJson-log
+          path: libs/data/generateFaqJson.log
+          retention-days: 90
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -191,19 +241,7 @@ jobs:
           branch: chore/update_faq
           commit-message: 'chore: update FAQ'
           title: 'chore: update FAQ'
-          body: |
-            Cette pull request a été crée automatiquement pour mettre à jour les FAQ.
-
-            ### :warning: Merci de bien vérifier les changements avant de merge. :warning:
-
-            ### Liste de points problématiques automatiquement détectés:
-
-            :fire: :fire: :fire: :fire: critique
-            :fire: :fire:  important
-            :fire: mineur
-            :warning:  info
-
-            ${{ env.log_content }}
+          body-path: ${{ runner.temp }}/pr-body.md
           draft: false
 
   send-programs-mails:
@@ -226,6 +264,6 @@ jobs:
         env:
           BASEROW_TOKEN: '${{secrets.BASEROW_TOKEN}}'
           BREVO_API_TOKEN: '${{secrets.BREVO_API_TOKEN}}'
-          BREVO_SENDER_ID	: '${{secrets.BREVO_SENDER_ID}}'
+          BREVO_SENDER_ID: '${{secrets.BREVO_SENDER_ID}}'
 
         run: npm run send:program:mails


### PR DESCRIPTION
Corrige l'échec du workflow **Update Data** (job `update-programs`, étape *Create Pull Request*), visible sur le [run #30093580309](https://github.com/betagouv/mission-transition-ecologique/actions/runs/30093580309), et clôt au passage la déprécation Node 20.

## 1. Échec bloquant : `Argument list too long`

### Cause

Le corps des PR auto-générées injectait le log de validation via `$GITHUB_ENV` → input `body` de `peter-evans/create-pull-request`. GitHub passe cet input à l'action via la variable d'environnement `INPUT_BODY`. Le log de dispositifs a dépassé la limite d'une variable d'env sous Linux (~128 Ko, `MAX_ARG_STRLEN`) : au démarrage du process node de l'action, `execve` renvoie `E2BIG` → **`Argument list too long`** et le job plante.

Ce n'est pas une régression de code : c'est le volume d'erreurs de validation (liens cassés Baserow, ~867 lignes ce run) qui a franchi le seuil.

### Correctif (jobs `update-programs`, `update-projects`, `update-faq`)

- **`body-path` au lieu de `body`** : le corps est écrit dans un fichier (`${{ runner.temp }}/pr-body.md`, hors workspace pour ne pas être committé dans la PR), puis lu par l'action. Plus de passage par variable d'env → plus de `E2BIG`.
- **Troncature à 55 000 caractères** : un corps de PR est plafonné à 65 536 caractères côté API GitHub ; la troncature évite un futur échec de l'API.
- **Upload du log complet en artefact** (`actions/upload-artifact`, rétention 90 j) : le log intégral reste accessible depuis le run. Quand le corps est tronqué, une note avec le lien vers le run est ajoutée pour ne rien perdre.
- **Bonus** : correction d'un TAB parasite (YAML techniquement invalide, toléré par GitHub) dans le job `send-programs-mails`.

## 2. Déprécation Node 20

GitHub déprécie le runtime Node 20 des actions. Mise à jour vers les versions qui tournent sur **Node 24** :

| Action | Avant | Après |
| --- | --- | --- |
| `actions/checkout` | v4 | **v5** |
| `actions/setup-node` | v3 | **v5** |
| `peter-evans/create-pull-request` | v6 | **v8** (`body-path` toujours supporté) |
| `actions/upload-artifact` | v4 (ajouté ici) | **v7** |

> ℹ️ Sans impact sur le **Node 22 du projet** (`.nvmrc` / `matrix.node-version`), qui concerne les étapes `npm` : ce bump ne touche que le runtime interne d'exécution des actions.